### PR TITLE
Chore: rename module blink to maclow

### DIFF
--- a/app/01net_blink/README.md
+++ b/app/01net_blink/README.md
@@ -1,1 +1,1 @@
-# Blink
+# blink

--- a/app/01net_blink/main.c
+++ b/app/01net_blink/main.c
@@ -1,8 +1,8 @@
 /**
  * @file
- * @ingroup     net_blink
+ * @ingroup     net_maclow
  *
- * @brief       Example on how to use the Blink driver
+ * @brief       Example on how to use the maclow driver
  *
  * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
  *
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "blink.h"
+#include "maclow.h"
 #include "scheduler.h"
 #include "device.h"
 

--- a/app/01net_scheduler/main.c
+++ b/app/01net_scheduler/main.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 
 #include "scheduler.h"
-#include "blink.h"
+#include "maclow.h"
 #include "timer_hf.h"
 #include "device.h"
 

--- a/app/app-drv-net.emProject
+++ b/app/app-drv-net.emProject
@@ -3,7 +3,7 @@
   <project Name="01net_lists">
     <configuration
       Name="Common"
-      project_dependencies="01net_scan(01net);01net_blink(01net);00drv_timer_hf(00drv)"
+      project_dependencies="01net_scan(01net);01net_maclow(01net);00drv_timer_hf(00drv)"
       project_directory="01net_lists"
       project_type="Executable" />
     <configuration Name="Debug" linker_printf_fp_enabled="Float" />
@@ -28,7 +28,7 @@
   <project Name="01net_scheduler">
     <configuration
       Name="Common"
-      project_dependencies="01net_scheduler(01net);01net_blink(01net);00drv_timer_hf(00drv)"
+      project_dependencies="01net_scheduler(01net);01net_maclow(01net);00drv_timer_hf(00drv)"
       project_directory="01net_scheduler"
       project_type="Executable" />
     <configuration Name="Debug" linker_printf_fp_enabled="Float" />
@@ -50,11 +50,11 @@
       <file file_name="$(ProjectDir)/../../nRF/System/cpu.c" />
     </folder>
   </project>
-  <project Name="01net_blink">
+  <project Name="01net_maclow">
     <configuration
       Name="Common"
-      project_dependencies="01net_blink(01net);01net_scheduler(01net);01net_blink(01net);00drv_timer_hf(00drv)"
-      project_directory="01net_blink"
+      project_dependencies="01net_maclow(01net);01net_scheduler(01net);01net_maclow(01net);00drv_timer_hf(00drv)"
+      project_directory="01net_maclow"
       project_type="Executable" />
     <configuration Name="Debug" linker_printf_fp_enabled="Float" />
     <folder Name="Setup">

--- a/net/maclow.h
+++ b/net/maclow.h
@@ -1,8 +1,8 @@
-#ifndef __BLINK_H
-#define __BLINK_H
+#ifndef __MACLOW_H
+#define __MACLOW_H
 
 /**
- * @defgroup    net_blink      TSCH radio driver
+ * @defgroup    net_maclow      MAC-low radio driver
  * @ingroup     drv
  * @brief       Driver for Time-Slotted Channel Hopping (TSCH)
  *
@@ -87,4 +87,4 @@ typedef void (*bl_cb_t)(uint8_t *packet, uint8_t length);  ///< Function pointer
  */
 void bl_init(node_type_t node_type, bl_cb_t application_callback);
 
-#endif
+#endif // __MACLOW_H

--- a/net/maclow/maclow.c
+++ b/net/maclow/maclow.c
@@ -1,8 +1,8 @@
 /**
  * @file
- * @ingroup     net_blink
+ * @ingroup     net_maclow
  *
- * @brief       Driver for Time-Slotted Channel Hopping (TSCH)
+ * @brief       Lower MAC driver for Time-Slotted Channel Hopping (TSCH)
  *
  * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
  *
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-#include "blink.h"
+#include "maclow.h"
 #include "scheduler.h"
 #include "radio.h"
 #include "timer_hf.h"

--- a/net/net.emProject
+++ b/net/net.emProject
@@ -22,13 +22,13 @@
     <file file_name="all_schedules.c" />
     <file file_name="../scheduler.h" />
   </project>
-  <project Name="01net_blink">
+  <project Name="01net_maclow">
     <configuration
       Name="Common"
       project_dependencies="01net_scheduler(01net);00drv_radio(00drv);00drv_timer_hf(00drv);00drv_gpio(00drv)"
-      project_directory="blink"
+      project_directory="maclow"
       project_type="Library" />
-    <file file_name="blink.c" />
-    <file file_name="../blink.h" />
+    <file file_name="maclow.c" />
+    <file file_name="../maclow.h" />
   </project>
 </solution>

--- a/net/scan.h
+++ b/net/scan.h
@@ -26,7 +26,7 @@ typedef struct {
 
 typedef struct {
     uint64_t   gateway_id;
-    bl_rssi_t  rssi[DOTLINK_N_BLE_ADVERTISING_FREQUENCIES]; // channels 37, 38, 39
+    bl_rssi_t  rssi[BLINK_N_BLE_ADVERTISING_FREQUENCIES]; // channels 37, 38, 39
 } bl_scan_t;
 
 //=========================== prototypes ======================================

--- a/net/scheduler.h
+++ b/net/scheduler.h
@@ -2,7 +2,7 @@
 #define __SCHEDULER_H
 
 /**
- * @defgroup    net_blink      SCHEDULER radio driver
+ * @defgroup    net_scheduler      SCHEDULER radio driver
  * @ingroup     drv
  * @brief       Driver for the TSCH scheduler
  *
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 #include <nrf.h>
 
-#include "blink.h"
+#include "maclow.h"
 
 //=========================== defines ==========================================
 

--- a/net/scheduler/all_schedules.c
+++ b/net/scheduler/all_schedules.c
@@ -1,8 +1,8 @@
 /**
  * @file
- * @ingroup     net_blink
+ * @ingroup     net_maclow
  *
- * @brief       Driver for Time-Slotted Channel Hopping (TSCH)
+ * @brief       Fixed schedules
  *
  * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
  *

--- a/net/scheduler/scheduler.c
+++ b/net/scheduler/scheduler.c
@@ -1,8 +1,8 @@
 /**
  * @file
- * @ingroup     net_blink
+ * @ingroup     net_scheduler
  *
- * @brief       Driver for Time-Slotted Channel Hopping (TSCH)
+ * @brief       The blink scheduler
  *
  * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
  *
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 
 #include "scheduler.h"
-#include "blink.h"
+#include "maclow.h"
 #include "device.h"
 #if defined(NRF5340_XXAA) && defined(NRF_NETWORK)
 #include "ipc.h"


### PR DESCRIPTION
The `blink` name is reserved for the high level API (issue #19).