### PR TITLE
Allow automatic keepalive packets

### DIFF
--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -87,7 +87,7 @@ int main(void)
 
         bl_tx(packet, packet_len);
 
-        // sleep for some time
-        bl_timer_hf_delay_us(BLINK_APP_TIMER_DEV, bl_scheduler_get_active_schedule_slot_count() * BLINK_WHOLE_SLOT_DURATION * 2);
+        // sleep for 500 ms
+        bl_timer_hf_delay_ms(BLINK_APP_TIMER_DEV, 500);
     }
 }

--- a/app/03app_node/main.c
+++ b/app/03app_node/main.c
@@ -81,8 +81,8 @@ int main(void)
 
             bl_tx(packet, packet_len);
 
-            // sleep for some time
-            bl_timer_hf_delay_us(BLINK_APP_TIMER_DEV, bl_scheduler_get_active_schedule_slot_count() * BLINK_WHOLE_SLOT_DURATION * 2);
+            // sleep for 500 ms
+            bl_timer_hf_delay_ms(BLINK_APP_TIMER_DEV, 500);
         }
     }
 }

--- a/blink/mac.c
+++ b/blink/mac.c
@@ -519,6 +519,9 @@ static void activity_ri4(uint32_t ts) {
                 mac_vars.blink_event_callback(BLINK_NEW_PACKET, event_data);
             }
             break;
+        case BLINK_PACKET_KEEPALIVE:
+            // at this point can just ignore keepalives, since node info was already saved in the association module
+            break;
     }
 
     end_slot();

--- a/blink/mac.c
+++ b/blink/mac.c
@@ -190,6 +190,10 @@ uint64_t bl_mac_get_asn(void) {
     return mac_vars.asn;
 }
 
+uint64_t bl_mac_get_synced_gateway(void) {
+    return mac_vars.synced_gateway;
+}
+
 //=========================== private ==========================================
 
 static void set_slot_state(bl_mac_state_t state) {

--- a/blink/protocol.c
+++ b/blink/protocol.c
@@ -24,6 +24,10 @@ size_t bl_build_packet_data(uint8_t *buffer, uint64_t dst, uint8_t *data, size_t
     return header_len + data_len;
 }
 
+size_t bl_build_packet_keepalive(uint8_t *buffer, uint64_t dst) {
+    return _set_header(buffer, dst, BLINK_PACKET_KEEPALIVE);
+}
+
 size_t bl_build_packet_join_request(uint8_t *buffer, uint64_t dst) {
     return _set_header(buffer, dst, BLINK_PACKET_JOIN_REQUEST);
 }

--- a/blink/protocol.h
+++ b/blink/protocol.h
@@ -16,6 +16,7 @@ typedef enum {
     BLINK_PACKET_BEACON = 1,
     BLINK_PACKET_JOIN_REQUEST = 2,
     BLINK_PACKET_JOIN_RESPONSE = 3,
+    BLINK_PACKET_KEEPALIVE = 4,
     BLINK_PACKET_DATA = 5,
 } bl_packet_type_t;
 
@@ -44,6 +45,8 @@ size_t bl_build_packet_data(uint8_t *buffer, uint64_t dst, uint8_t *data, size_t
 size_t bl_build_packet_join_request(uint8_t *buffer, uint64_t dst);
 
 size_t bl_build_packet_join_response(uint8_t *buffer, uint64_t dst);
+
+size_t bl_build_packet_keepalive(uint8_t *buffer, uint64_t dst);
 
 size_t bl_build_packet_beacon(uint8_t *buffer, uint64_t asn, uint8_t remaining_capacity, uint8_t active_schedule_id);
 

--- a/blink/queue.c
+++ b/blink/queue.c
@@ -75,7 +75,7 @@ uint8_t bl_queue_next_packet(slot_type_t slot_type, uint8_t *packet) {
                 bl_queue_pop();
             } else if (BLINK_AUTO_UPLINK_KEEPALIVE) {
                 // send a keepalive packet
-                len = bl_build_packet_keepalive(packet);
+                len = bl_build_packet_keepalive(packet, bl_mac_get_synced_gateway());
             }
         }
     }

--- a/blink/queue.c
+++ b/blink/queue.c
@@ -73,6 +73,9 @@ uint8_t bl_queue_next_packet(slot_type_t slot_type, uint8_t *packet) {
             if (len) {
                 // actually pop the packet from the queue
                 bl_queue_pop();
+            } else if (BLINK_AUTO_UPLINK_KEEPALIVE) {
+                // send a keepalive packet
+                len = bl_build_packet_keepalive(packet);
             }
         }
     }

--- a/blink/queue.h
+++ b/blink/queue.h
@@ -10,6 +10,8 @@
 
 #define BLINK_PACKET_QUEUE_SIZE (8) // must be a power of 2
 
+#define BLINK_AUTO_UPLINK_KEEPALIVE 1 // whether to send a keepalive packet when there is nothing to send
+
 //=========================== prototypes ======================================
 
 void bl_queue_add(uint8_t *packet, uint8_t length);


### PR DESCRIPTION
fixes #48 

flag `BLINK_AUTO_UPLINK_KEEPALIVE` can be used to disable this behavior