### PR TITLE
Improve API names

### DIFF
--- a/app/01blink_maclow/main.c
+++ b/app/01blink_maclow/main.c
@@ -61,7 +61,7 @@ int main(void) {
 
     print_slot_timing();
 
-    bl_set_node_type(node_type);
+    blink_set_node_type(node_type);
 
     bl_assoc_init(blink_event_callback);
 

--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -46,7 +46,7 @@ int main(void)
     printf("Hello Blink Gateway\n");
     bl_timer_hf_init(BLINK_APP_TIMER_DEV);
 
-    bl_init(BLINK_GATEWAY, &schedule_minuscule, &blink_event_callback);
+    blink_init(BLINK_GATEWAY, &schedule_minuscule, &blink_event_callback);
 
     while (1) {
         __SEV();
@@ -55,19 +55,19 @@ int main(void)
 
         // test: send a broadcast packet
         uint8_t packet_len = bl_build_packet_data(packet, BLINK_BROADCAST_ADDRESS, payload, payload_len);
-        bl_tx(packet, packet_len);
+        blink_tx(packet, packet_len);
 
         // sleep for 500 ms
         bl_timer_hf_delay_ms(BLINK_APP_TIMER_DEV, 500);
 
         // test: enqueue packets to all connected nodes
         uint64_t nodes[BLINK_MAX_NODES] = { 0 };
-        uint8_t nodes_len = bl_gateway_get_nodes(nodes);
+        uint8_t nodes_len = blink_gateway_get_nodes(nodes);
         for (int i = 0; i < nodes_len; i++) {
             printf("Enqueing TX to node %d: %016llX\n", i, nodes[i]);
             payload[0] = i;
             uint8_t packet_len = bl_build_packet_data(packet, nodes[i], payload, payload_len);
-            bl_tx(packet, packet_len);
+            blink_tx(packet, packet_len);
         }
 
         // sleep for 500 ms
@@ -89,13 +89,13 @@ void blink_event_callback(bl_event_t event, bl_event_data_t event_data) {
         case BLINK_NODE_JOINED:
             printf("New node joined: %016llX\n", event_data.data.node_info.node_id);
             uint64_t joined_nodes[BLINK_MAX_NODES] = { 0 };
-            uint8_t joined_nodes_len = bl_gateway_get_nodes(joined_nodes);
+            uint8_t joined_nodes_len = blink_gateway_get_nodes(joined_nodes);
             printf("Number of connected nodes: %d\n", joined_nodes_len);
             // TODO: send list of joined_nodes to Edge Gateway via UART
             break;
         case BLINK_NODE_LEFT:
             printf("Node left: %016llX, reason: %u\n", event_data.data.node_info.node_id, event_data.tag);
-            printf("Number of connected nodes: %d\n", bl_gateway_count_nodes());
+            printf("Number of connected nodes: %d\n", blink_gateway_count_nodes());
             break;
         case BLINK_ERROR:
             printf("Error\n");

--- a/app/03app_node/main.c
+++ b/app/03app_node/main.c
@@ -45,15 +45,15 @@ int main(void)
     printf("Hello Blink Node\n");
     bl_timer_hf_init(BLINK_APP_TIMER_DEV);
 
-    bl_init(BLINK_NODE, &schedule_minuscule, &blink_event_callback);
+    blink_init(BLINK_NODE, &schedule_minuscule, &blink_event_callback);
 
     while (1) {
         __SEV();
         __WFE();
         __WFE();
 
-        if (bl_node_is_connected()) {
-            bl_node_tx(payload, payload_len);
+        if (blink_node_is_connected()) {
+            blink_node_tx(payload, payload_len);
 
             // sleep for 500 ms
             bl_timer_hf_delay_ms(BLINK_APP_TIMER_DEV, 500);

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -1,4 +1,15 @@
-#include <nrf.h>
+/**
+ * @file
+ * @ingroup     blink
+ *
+ * @brief       Implementation of the blink protocol
+ *
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ *
+ * @copyright Inria, 2024
+ */
+
+ #include <nrf.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -32,10 +43,11 @@ static blink_vars_t _blink_vars = { 0 };
 static void event_callback(bl_event_t event, bl_event_data_t event_data);
 
 //=========================== public ===========================================
+// in this library, user-facing functions begin with blink_*, while internal functions begin with bl_*
 
 // -------- common --------
 
-void bl_init(bl_node_type_t node_type, schedule_t *app_schedule, bl_event_cb_t app_event_callback) {
+void blink_init(bl_node_type_t node_type, schedule_t *app_schedule, bl_event_cb_t app_event_callback) {
     _blink_vars.node_type = node_type;
     _blink_vars.app_event_callback = app_event_callback;
 
@@ -44,44 +56,42 @@ void bl_init(bl_node_type_t node_type, schedule_t *app_schedule, bl_event_cb_t a
     bl_mac_init(node_type, event_callback);
 }
 
-void bl_tx(uint8_t *packet, uint8_t length) {
-    // enqueue for transmission
+void blink_tx(uint8_t *packet, uint8_t length) {
     bl_queue_add(packet, length);
 }
 
-bl_node_type_t bl_get_node_type(void) {
+bl_node_type_t blink_get_node_type(void) {
     return _blink_vars.node_type;
 }
 
-void bl_set_node_type(bl_node_type_t node_type) {
+void blink_set_node_type(bl_node_type_t node_type) {
     _blink_vars.node_type = node_type;
 }
 
 // -------- gateway ----------
 
-size_t bl_gateway_get_nodes(uint64_t *nodes) {
+size_t blink_gateway_get_nodes(uint64_t *nodes) {
     memcpy(nodes, _blink_vars.joined_nodes, _blink_vars.joined_nodes_len * sizeof(uint64_t));
     return _blink_vars.joined_nodes_len;
 }
 
-size_t bl_gateway_count_nodes(void) {
+size_t blink_gateway_count_nodes(void) {
     return _blink_vars.joined_nodes_len;
 }
 
 // -------- node ----------
 
-void bl_node_tx(uint8_t *payload, uint8_t payload_len) {
+void blink_node_tx(uint8_t *payload, uint8_t payload_len) {
     uint8_t packet[BLINK_PACKET_MAX_SIZE];
-    uint8_t len = bl_build_packet_data(packet, bl_node_gateway_id(), payload, payload_len);
-    // enqueue for transmission
+    uint8_t len = bl_build_packet_data(packet, blink_node_gateway_id(), payload, payload_len);
     bl_queue_add(packet, len);
 }
 
-bool bl_node_is_connected(void) {
+bool blink_node_is_connected(void) {
     return bl_assoc_is_joined();
 }
 
-uint64_t bl_node_gateway_id(void) {
+uint64_t blink_node_gateway_id(void) {
     return bl_mac_get_synced_gateway();
 }
 
@@ -95,7 +105,7 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
         return;
     }
 
-    if (bl_get_node_type() == BLINK_GATEWAY) {
+    if (blink_get_node_type() == BLINK_GATEWAY) {
         bool from_joined_node = bl_assoc_gateway_node_is_joined(header->src);
 
         switch (header->type) {
@@ -142,7 +152,7 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
                 break;
         }
 
-    } else if (bl_get_node_type() == BLINK_NODE) {
+    } else if (blink_get_node_type() == BLINK_NODE) {
         bool from_my_gateway = header->src == bl_mac_get_synced_gateway() && bl_assoc_get_state() == JOIN_STATE_JOINED;
 
         switch (header->type) {

--- a/blink/blink.h
+++ b/blink/blink.h
@@ -1,6 +1,17 @@
 #ifndef __BLINK_H
 #define __BLINK_H
 
+/**
+ * @defgroup    blink      Blink
+ * @brief       Implementation of the blink protocol
+ *
+ * @{
+ * @file
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ * @copyright Inria, 2024-now
+ * @}
+ */
+
 #include <stdint.h>
 #include <stdbool.h>
 #include "models.h"
@@ -12,17 +23,17 @@
 
 //=========================== prototypes ==========================================
 
-void bl_init(bl_node_type_t node_type, schedule_t *app_schedule, bl_event_cb_t app_event_callback);
-void bl_tx(uint8_t *packet, uint8_t length);
-bl_node_type_t bl_get_node_type(void);
-void bl_set_node_type(bl_node_type_t node_type);
+void blink_init(bl_node_type_t node_type, schedule_t *app_schedule, bl_event_cb_t app_event_callback);
+void blink_tx(uint8_t *packet, uint8_t length);
+bl_node_type_t blink_get_node_type(void);
+void blink_set_node_type(bl_node_type_t node_type);
 
-size_t bl_gateway_get_nodes(uint64_t *nodes);
-size_t bl_gateway_count_nodes(void);
+size_t blink_gateway_get_nodes(uint64_t *nodes);
+size_t blink_gateway_count_nodes(void);
 
-void bl_node_tx(uint8_t *payload, uint8_t payload_len);
-bool bl_node_is_connected(void);
-uint64_t bl_node_gateway_id(void);
+void blink_node_tx(uint8_t *payload, uint8_t payload_len);
+bool blink_node_is_connected(void);
+uint64_t blink_node_gateway_id(void);
 
 // -------- internal api --------
 void bl_handle_packet(uint8_t *packet, uint8_t length);

--- a/blink/mac.c
+++ b/blink/mac.c
@@ -8,6 +8,7 @@
  *
  * @copyright Inria, 2024
  */
+
 #include <nrf.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/blink/models.h
+++ b/blink/models.h
@@ -1,6 +1,18 @@
 #ifndef __MODELS_H
 #define __MODELS_H
 
+/**
+ * @defgroup    models      common models
+ * @ingroup     blink
+ * @brief       Common models used in the blink protocol
+ *
+ * @{
+ * @file
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ * @copyright Inria, 2024-now
+ * @}
+ */
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <nrf.h>

--- a/blink/protocol.h
+++ b/blink/protocol.h
@@ -1,6 +1,17 @@
 #ifndef __PROTOCOL_H
 #define __PROTOCOL_H
 
+/**
+ * @ingroup     blink
+ * @brief       Packet format and building functions
+ *
+ * @{
+ * @file
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ * @copyright Inria, 2024-now
+ * @}
+ */
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <nrf.h>

--- a/blink/queue.c
+++ b/blink/queue.c
@@ -1,3 +1,14 @@
+/**
+ * @file
+ * @ingroup     queue
+ *
+ * @brief       Packet queue management
+ *
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ *
+ * @copyright Inria, 2024
+ */
+
 #include <nrf.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -41,7 +52,7 @@ static queue_vars_t queue_vars = { 0 };
 uint8_t bl_queue_next_packet(slot_type_t slot_type, uint8_t *packet) {
     uint8_t len = 0;
 
-    if (bl_get_node_type() == BLINK_GATEWAY) {
+    if (blink_get_node_type() == BLINK_GATEWAY) {
         if (slot_type == SLOT_TYPE_BEACON) {
             // prepare a beacon packet with current asn, remaining capacity and active schedule id
             len = bl_build_packet_beacon(
@@ -62,7 +73,7 @@ uint8_t bl_queue_next_packet(slot_type_t slot_type, uint8_t *packet) {
                 }
             }
         }
-    } else if (bl_get_node_type() == BLINK_NODE) {
+    } else if (blink_get_node_type() == BLINK_NODE) {
         if (slot_type == SLOT_TYPE_SHARED_UPLINK) {
             if (bl_assoc_node_ready_to_join()) {
                 bl_assoc_set_state(JOIN_STATE_JOINING);

--- a/blink/queue.h
+++ b/blink/queue.h
@@ -1,6 +1,17 @@
 #ifndef __QUEUE_H
 #define __QUEUE_H
 
+/**
+ * @ingroup     blink
+ * @brief       Queue management
+ *
+ * @{
+ * @file
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ * @copyright Inria, 2024-now
+ * @}
+ */
+
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/blink/scan.c
+++ b/blink/scan.c
@@ -1,3 +1,14 @@
+/**
+ * @file
+ * @ingroup     blink
+ *
+ * @brief       Scan list management
+ *
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ *
+ * @copyright Inria, 2024
+ */
+
 #include <nrf.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/blink/scan.h
+++ b/blink/scan.h
@@ -1,6 +1,17 @@
 #ifndef __SCAN_H
 #define __SCAN_H
 
+/**
+ * @ingroup     blink
+ * @brief       Scan management
+ *
+ * @{
+ * @file
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ * @copyright Inria, 2024-now
+ * @}
+ */
+
 #include <nrf.h>
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
Now, user-facing functions begin with blink_*, while internal functions begin with bl_*

Examples:
- user facing: `blink_init`, `blink_tx`, `blink_node_is_connected` 
- internal: `bl_mac_init`, `bl_handle_packet`, `bl_scheduler_tick` 