### PR TITLE
Tiny fixes for annoying bugs during join

### DIFF
--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -95,18 +95,18 @@ void blink_event_callback(bl_event_t event, bl_event_data_t event_data) {
             break;
         }
         case BLINK_NODE_JOINED:
-            //printf("New node joined: %016llX\n", event_data.data.node_info.node_id);
+            printf("New node joined: %016llX\n", event_data.data.node_info.node_id);
             //uint64_t joined_nodes[BLINK_MAX_NODES] = { 0 };
             //uint8_t joined_nodes_len = blink_gateway_get_nodes(joined_nodes);
             //printf("Number of connected nodes: %d\n", joined_nodes_len);
             // TODO: send list of joined_nodes to Edge Gateway via UART
             break;
         case BLINK_NODE_LEFT:
-            //printf("Node left: %016llX, reason: %u\n", event_data.data.node_info.node_id, event_data.tag);
+            printf("Node left: %016llX, reason: %u\n", event_data.data.node_info.node_id, event_data.tag);
             //printf("Number of connected nodes: %d\n", blink_gateway_count_nodes());
             break;
         case BLINK_ERROR:
-            printf("Error\n");
+            printf("Error, reason: %u\n", event_data.tag);
             break;
         default:
             break;

--- a/app/03app_gateway/main.c
+++ b/app/03app_gateway/main.c
@@ -116,7 +116,7 @@ void blink_event_callback(bl_event_t event, bl_event_data_t event_data) {
 //=========================== private ========================================
 
 void _debug_print_schedule(void) {
-    return; // skip printing, just enable when really debugging
+    //return; // skip printing, just enable when really debugging
 
     uint8_t schedule_len = schedule_minuscule.n_cells;
     printf("Schedule cells: ");

--- a/app/03app_node/main.c
+++ b/app/03app_node/main.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+#include "bl_gpio.h"
 #include "bl_radio.h"
 #include "bl_timer_hf.h"
 #include "blink.h"
@@ -25,7 +26,18 @@ typedef struct {
     bool dummy;
 } node_vars_t;
 
+typedef enum {
+    OFF,
+    RED,
+    GREEN,
+    BLUE,
+} led_color_t;
+
 //=========================== variables ========================================
+
+bl_gpio_t _r_led_pin = { .port = 0, .pin = 28 };
+bl_gpio_t _g_led_pin = { .port = 0, .pin = 2 };
+bl_gpio_t _b_led_pin = { .port = 0, .pin = 3 };
 
 node_vars_t node_vars = { 0 };
 
@@ -36,6 +48,8 @@ extern schedule_t schedule_minuscule, schedule_tiny, schedule_small, schedule_hu
 
 //=========================== prototypes =======================================
 
+static void debug_init_minimote(void);
+static void debug_set_rgb(led_color_t color);
 static void blink_event_callback(bl_event_t event, bl_event_data_t event_data);
 
 //=========================== main =============================================
@@ -44,6 +58,8 @@ int main(void)
 {
     printf("Hello Blink Node\n");
     bl_timer_hf_init(BLINK_APP_TIMER_DEV);
+    debug_init_minimote();
+    debug_set_rgb(RED);
 
     blink_init(BLINK_NODE, &schedule_minuscule, &blink_event_callback);
 
@@ -72,22 +88,93 @@ static void blink_event_callback(bl_event_t event, bl_event_data_t event_data) {
                 printf("%02X ", packet.payload[i]);
             }
             printf("\n");
+            debug_set_rgb(BLUE);
+            bl_timer_hf_delay_ms(BLINK_APP_TIMER_DEV, 50);
+            debug_set_rgb(GREEN);
             break;
         }
         case BLINK_CONNECTED: {
             uint64_t gateway_id = event_data.data.gateway_info.gateway_id;
             printf("Connected to gateway %016llX\n", gateway_id);
+            debug_set_rgb(GREEN);
             break;
         }
         case BLINK_DISCONNECTED: {
             uint64_t gateway_id = event_data.data.gateway_info.gateway_id;
             printf("Disconnected from gateway %016llX, reason: %u\n", gateway_id, event_data.tag);
+            debug_set_rgb(RED);
             break;
         }
         case BLINK_ERROR:
             printf("Error\n");
             break;
         default:
+            break;
+    }
+}
+
+//=========================== debug ========================================
+
+static void debug_init_minimote(void) {
+#ifndef BOARD_NRF52833DK
+    return;
+#endif
+    // Make sure the mini-mote is running at 3.0v
+    // Might need a re-start to take effect
+    if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VOUT_3V0) {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+        }
+        NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V0;
+
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+        }
+    }
+    bl_gpio_init(&_r_led_pin, BL_GPIO_OUT);
+    bl_gpio_init(&_g_led_pin, BL_GPIO_OUT);
+    bl_gpio_init(&_b_led_pin, BL_GPIO_OUT);
+
+    bl_gpio_t _reg_pin = { .port = 0, .pin = 30 };
+    // Turn ON the DotBot board regulator if provided
+    bl_gpio_init(&_reg_pin, BL_GPIO_OUT);
+    bl_gpio_set(&_reg_pin);
+}
+
+
+static void debug_set_rgb(led_color_t color) {
+#ifndef BOARD_NRF52833DK
+    return;
+#endif
+    switch (color) {
+        case RED:
+            bl_gpio_clear(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+
+        case GREEN:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_clear(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+
+        case BLUE:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_clear(&_b_led_pin);
+            break;
+
+        case OFF:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+
+        default:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
             break;
     }
 }

--- a/app/03app_node/main.c
+++ b/app/03app_node/main.c
@@ -6,7 +6,7 @@
  *
  * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
  *
- * @copyright Inria, 2024
+ * @copyright Inria, 2025
  */
 #include <nrf.h>
 #include <stdio.h>
@@ -18,6 +18,8 @@
 #include "blink.h"
 #include "packet.h"
 
+#include "minimote.h"
+
 //=========================== defines ==========================================
 
 #define BLINK_APP_TIMER_DEV 1
@@ -26,18 +28,7 @@ typedef struct {
     bool dummy;
 } node_vars_t;
 
-typedef enum {
-    OFF,
-    RED,
-    GREEN,
-    BLUE,
-} led_color_t;
-
 //=========================== variables ========================================
-
-bl_gpio_t _r_led_pin = { .port = 0, .pin = 28 };
-bl_gpio_t _g_led_pin = { .port = 0, .pin = 2 };
-bl_gpio_t _b_led_pin = { .port = 0, .pin = 3 };
 
 node_vars_t node_vars = { 0 };
 
@@ -48,8 +39,6 @@ extern schedule_t schedule_minuscule, schedule_tiny, schedule_small, schedule_hu
 
 //=========================== prototypes =======================================
 
-static void debug_init_minimote(void);
-static void debug_set_rgb(led_color_t color);
 static void blink_event_callback(bl_event_t event, bl_event_data_t event_data);
 
 //=========================== main =============================================
@@ -58,8 +47,8 @@ int main(void)
 {
     printf("Hello Blink Node\n");
     bl_timer_hf_init(BLINK_APP_TIMER_DEV);
-    debug_init_minimote();
-    debug_set_rgb(RED);
+
+    board_init();
 
     blink_init(BLINK_NODE, &schedule_minuscule, &blink_event_callback);
 
@@ -88,93 +77,24 @@ static void blink_event_callback(bl_event_t event, bl_event_data_t event_data) {
                 printf("%02X ", packet.payload[i]);
             }
             printf("\n");
-            debug_set_rgb(BLUE);
-            bl_timer_hf_delay_ms(BLINK_APP_TIMER_DEV, 50);
-            debug_set_rgb(GREEN);
             break;
         }
         case BLINK_CONNECTED: {
             uint64_t gateway_id = event_data.data.gateway_info.gateway_id;
             printf("Connected to gateway %016llX\n", gateway_id);
-            debug_set_rgb(GREEN);
+            board_set_rgb(GREEN);
             break;
         }
         case BLINK_DISCONNECTED: {
             uint64_t gateway_id = event_data.data.gateway_info.gateway_id;
             printf("Disconnected from gateway %016llX, reason: %u\n", gateway_id, event_data.tag);
-            debug_set_rgb(RED);
+            board_set_rgb(RED);
             break;
         }
         case BLINK_ERROR:
             printf("Error\n");
             break;
         default:
-            break;
-    }
-}
-
-//=========================== debug ========================================
-
-static void debug_init_minimote(void) {
-#ifndef BOARD_NRF52833DK
-    return;
-#endif
-    // Make sure the mini-mote is running at 3.0v
-    // Might need a re-start to take effect
-    if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VOUT_3V0) {
-        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
-        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
-        }
-        NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V0;
-
-        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
-        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
-        }
-    }
-    bl_gpio_init(&_r_led_pin, BL_GPIO_OUT);
-    bl_gpio_init(&_g_led_pin, BL_GPIO_OUT);
-    bl_gpio_init(&_b_led_pin, BL_GPIO_OUT);
-
-    bl_gpio_t _reg_pin = { .port = 0, .pin = 30 };
-    // Turn ON the DotBot board regulator if provided
-    bl_gpio_init(&_reg_pin, BL_GPIO_OUT);
-    bl_gpio_set(&_reg_pin);
-}
-
-
-static void debug_set_rgb(led_color_t color) {
-#ifndef BOARD_NRF52833DK
-    return;
-#endif
-    switch (color) {
-        case RED:
-            bl_gpio_clear(&_r_led_pin);
-            bl_gpio_set(&_g_led_pin);
-            bl_gpio_set(&_b_led_pin);
-            break;
-
-        case GREEN:
-            bl_gpio_set(&_r_led_pin);
-            bl_gpio_clear(&_g_led_pin);
-            bl_gpio_set(&_b_led_pin);
-            break;
-
-        case BLUE:
-            bl_gpio_set(&_r_led_pin);
-            bl_gpio_set(&_g_led_pin);
-            bl_gpio_clear(&_b_led_pin);
-            break;
-
-        case OFF:
-            bl_gpio_set(&_r_led_pin);
-            bl_gpio_set(&_g_led_pin);
-            bl_gpio_set(&_b_led_pin);
-            break;
-
-        default:
-            bl_gpio_set(&_r_led_pin);
-            bl_gpio_set(&_g_led_pin);
-            bl_gpio_set(&_b_led_pin);
             break;
     }
 }

--- a/app/03app_node/main.c
+++ b/app/03app_node/main.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 
 #include "bl_gpio.h"
+#include "bl_device.h"
 #include "bl_radio.h"
 #include "bl_timer_hf.h"
 #include "blink.h"
@@ -45,7 +46,7 @@ static void blink_event_callback(bl_event_t event, bl_event_data_t event_data);
 
 int main(void)
 {
-    printf("Hello Blink Node\n");
+    printf("Hello Blink Node %016llX\n", bl_device_id());
     bl_timer_hf_init(BLINK_APP_TIMER_DEV);
 
     board_init();

--- a/app/03app_node/minimote.c
+++ b/app/03app_node/minimote.c
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * @ingroup     app
+ *
+ * @brief       Blink Node application example
+ *
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ *
+ * @copyright Inria, 2025
+ */
+
+#include <nrf.h>
+#include "bl_gpio.h"
+
+#include "minimote.h"
+
+bl_gpio_t _r_led_pin = { .port = 0, .pin = 28 };
+bl_gpio_t _g_led_pin = { .port = 0, .pin = 2 };
+bl_gpio_t _b_led_pin = { .port = 0, .pin = 3 };
+
+void board_init(void) {
+    // Make sure the mini-mote is running at 3.0v
+    // Might need a re-start to take effect
+    if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VOUT_3V0) {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+        }
+        NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V0;
+
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+        }
+    }
+    bl_gpio_init(&_r_led_pin, BL_GPIO_OUT);
+    bl_gpio_init(&_g_led_pin, BL_GPIO_OUT);
+    bl_gpio_init(&_b_led_pin, BL_GPIO_OUT);
+    board_set_rgb(OFF);
+
+    bl_gpio_t _reg_pin = { .port = 0, .pin = 30 };
+    // Turn ON the DotBot board regulator if provided
+    bl_gpio_init(&_reg_pin, BL_GPIO_OUT);
+    bl_gpio_set(&_reg_pin);
+}
+
+
+void board_set_rgb(led_color_t color) {
+    switch (color) {
+        case RED:
+            bl_gpio_clear(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+
+        case GREEN:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_clear(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+
+        case BLUE:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_clear(&_b_led_pin);
+            break;
+
+        case OFF:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+
+        default:
+            bl_gpio_set(&_r_led_pin);
+            bl_gpio_set(&_g_led_pin);
+            bl_gpio_set(&_b_led_pin);
+            break;
+    }
+}

--- a/app/03app_node/minimote.c
+++ b/app/03app_node/minimote.c
@@ -34,7 +34,7 @@ void board_init(void) {
     bl_gpio_init(&_r_led_pin, BL_GPIO_OUT);
     bl_gpio_init(&_g_led_pin, BL_GPIO_OUT);
     bl_gpio_init(&_b_led_pin, BL_GPIO_OUT);
-    board_set_rgb(OFF);
+    board_set_rgb(BLUE);
 
     bl_gpio_t _reg_pin = { .port = 0, .pin = 30 };
     // Turn ON the DotBot board regulator if provided

--- a/app/03app_node/minimote.h
+++ b/app/03app_node/minimote.h
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * @ingroup     app
+ *
+ * @brief       Blink Node application example
+ *
+ * @author Geovane Fedrecheski <geovane.fedrecheski@inria.fr>
+ *
+ * @copyright Inria, 2025
+ */
+
+typedef enum {
+    OFF,
+    RED,
+    GREEN,
+    BLUE,
+} led_color_t;
+
+void board_init(void);
+void board_set_rgb(led_color_t color);

--- a/app/app-node.emProject
+++ b/app/app-node.emProject
@@ -18,6 +18,7 @@
     <folder Name="Source">
       <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
       <file file_name="main.c" />
+      <file file_name="minimote.c" />
     </folder>
     <folder Name="System">
       <file file_name="$(ProjectDir)/../../nRF/System/$(Target)_system_init.c" />

--- a/blink/association.c
+++ b/blink/association.c
@@ -249,6 +249,7 @@ void bl_assoc_node_keep_gateway_alive(uint64_t asn) {
 
 void bl_assoc_node_handle_disconnect(void) {
     bl_assoc_set_state(JOIN_STATE_IDLE);
+    bl_scheduler_node_deassign_myself_from_schedule();
     bl_event_data_t event_data = { .data.gateway_info.gateway_id = bl_mac_get_synced_gateway(), .tag = BLINK_PEER_LOST };
     assoc_vars.blink_event_callback(BLINK_DISCONNECTED, event_data);
 }

--- a/blink/association.h
+++ b/blink/association.h
@@ -42,7 +42,7 @@ void bl_assoc_node_handle_synced(void);
 bool bl_assoc_node_ready_to_join(void);
 void bl_assoc_node_start_joining(void);
 void bl_assoc_node_handle_joined(uint64_t gateway_id);
-void bl_assoc_node_handle_failed_join(void);
+bool bl_assoc_node_handle_failed_join(void);
 bool bl_assoc_node_too_long_waiting_for_join_response(void);
 bool bl_assoc_node_too_long_synced_without_joining(void);
 void bl_assoc_node_handle_give_up_joining(void);

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -100,7 +100,7 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
     bl_packet_header_t *header = (bl_packet_header_t *)packet;
 
     if (header->dst != bl_device_id() && header->dst != BLINK_BROADCAST_ADDRESS && header->type != BLINK_PACKET_BEACON) {
-        // ignore packets that are not for me, not broadcast, and not a beacon
+        // ignore packets that are not for me, and not broadcast, and not a beacon
         return;
     }
 
@@ -168,6 +168,10 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
             case BLINK_PACKET_JOIN_RESPONSE: {
                 if (bl_assoc_get_state() != JOIN_STATE_JOINING) {
                     // ignore if not in the JOINING state
+                    return;
+                }
+                if (header->dst != bl_device_id()) {
+                    // ignore if not for me
                     return;
                 }
                 // the first byte after the header contains the cell_id

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -153,17 +153,11 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
         }
 
     } else if (blink_get_node_type() == BLINK_NODE) {
-        bool from_my_gateway = header->src == bl_mac_get_synced_gateway() && bl_assoc_get_state() == JOIN_STATE_JOINED;
+        bool from_my_joined_gateway = header->src == bl_mac_get_synced_gateway() && bl_assoc_get_state() == JOIN_STATE_JOINED;
 
         switch (header->type) {
             case BLINK_PACKET_BEACON:
-                // bl_assoc_handle_beacon(packet, length, BLINK_FIXED_SCAN_CHANNEL, bl_mac_get_asn());
-                if (from_my_gateway) {
-                    bl_assoc_handle_beacon(packet, length, BLINK_FIXED_SCAN_CHANNEL, bl_mac_get_asn());
-                    bl_assoc_node_keep_gateway_alive(bl_mac_get_asn());
-                } else {
-                    bl_assoc_handle_beacon(packet, length, BLINK_FIXED_SCAN_CHANNEL, bl_mac_get_asn());
-                }
+                bl_assoc_handle_beacon(packet, length, BLINK_FIXED_SCAN_CHANNEL, bl_mac_get_asn());
                 break;
             case BLINK_PACKET_JOIN_RESPONSE: {
                 if (bl_assoc_get_state() != JOIN_STATE_JOINING) {
@@ -184,7 +178,7 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
                 break;
             }
             case BLINK_PACKET_DATA: {
-                if (!from_my_gateway) {
+                if (!from_my_joined_gateway) {
                     // ignore data packets from other gateways
                     return;
                 }
@@ -202,7 +196,7 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
                 break;
             }
             case BLINK_PACKET_KEEPALIVE:
-                if (!from_my_gateway) {
+                if (!from_my_joined_gateway) {
                     // ignore keep-alives from other gateways
                     return;
                 }

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -119,7 +119,7 @@ void bl_handle_packet(uint8_t *packet, uint8_t length) {
                     bl_queue_set_join_response(header->src, (uint8_t)cell_id); // at the packet level, max_nodes is limited to 256 (using uint8_t)
                     _blink_vars.app_event_callback(BLINK_NODE_JOINED, (bl_event_data_t){ .data.node_info.node_id = header->src });
                 } else {
-                    _blink_vars.app_event_callback(BLINK_ERROR, (bl_event_data_t){ 0 });
+                    _blink_vars.app_event_callback(BLINK_ERROR, (bl_event_data_t){ .tag = BLINK_GATEWAY_FULL });
                 }
                 break;
             }

--- a/blink/mac.c
+++ b/blink/mac.c
@@ -240,11 +240,19 @@ static void new_slot_synced(void) {
             return;
         } else if (bl_assoc_node_too_long_waiting_for_join_response()) {
             // too long without receiving a join response? notify the association module which will backfoff
-            bl_assoc_node_handle_failed_join();
+            bool keep_trying_to_join = bl_assoc_node_handle_failed_join();
+            if (!keep_trying_to_join) {
+                mac_vars.synced_gateway = 0;
+                mac_vars.synced_ts = 0;
+                set_slot_state(STATE_SLEEP);
+                end_slot();
+                start_scan();
+                return;
+            }
         } else if (bl_assoc_node_too_long_synced_without_joining()) {
             // too long synced without being able to join? give up and go back to scanning
             bl_assoc_node_handle_give_up_joining();
-            bl_assoc_set_state(JOIN_STATE_IDLE);
+
             mac_vars.synced_gateway = 0;
             mac_vars.synced_ts = 0;
             set_slot_state(STATE_SLEEP);

--- a/blink/mac.c
+++ b/blink/mac.c
@@ -242,9 +242,11 @@ static void new_slot_synced(void) {
             // too long without receiving a join response? notify the association module which will backfoff
             bl_assoc_node_handle_failed_join();
         } else if (bl_assoc_node_too_long_synced_without_joining()) {
-            // too long synced without being able to join? back to scanning
+            // too long synced without being able to join? give up and go back to scanning
             bl_assoc_node_handle_give_up_joining();
             bl_assoc_set_state(JOIN_STATE_IDLE);
+            mac_vars.synced_gateway = 0;
+            mac_vars.synced_ts = 0;
             set_slot_state(STATE_SLEEP);
             end_slot();
             start_scan();

--- a/blink/models.h
+++ b/blink/models.h
@@ -56,6 +56,7 @@ typedef enum {
     BLINK_HANDOVER = 1,
     BLINK_OUT_OF_SYNC = 2,
     BLINK_PEER_LOST = 3,
+    BLINK_GATEWAY_FULL = 4,
 } bl_event_tag_t;
 
 typedef struct {

--- a/blink/scheduler.c
+++ b/blink/scheduler.c
@@ -99,6 +99,16 @@ bool bl_scheduler_node_assign_myself_to_cell(uint16_t cell_index) {
     return false;
 }
 
+void bl_scheduler_node_deassign_myself_from_schedule(void) {
+    for (size_t i = 0; i < _schedule_vars.active_schedule_ptr->n_cells; i++) {
+        cell_t *cell = &_schedule_vars.active_schedule_ptr->cells[i];
+        if (cell->type == SLOT_TYPE_UPLINK && cell->assigned_node_id == bl_device_id()) {
+            cell->assigned_node_id = NULL;
+            cell->last_received_asn = 0;
+        }
+    }
+}
+
 // ------------ gateway functions ---------
 
 // to be called at the GATEWAY when processing a JOIN_REQUEST

--- a/blink/scheduler.h
+++ b/blink/scheduler.h
@@ -54,6 +54,8 @@ int16_t bl_scheduler_gateway_assign_next_available_uplink_cell(uint64_t node_id,
 
 bool bl_scheduler_node_assign_myself_to_cell(uint16_t cell_index);
 
+void bl_scheduler_node_deassign_myself_from_schedule(void);
+
 void bl_scheduler_gateway_decrease_nodes_counter(void);
 
 uint8_t bl_scheduler_gateway_remaining_capacity(void);


### PR DESCRIPTION
Fixed several tiny things that were causing (re)join issues:
- node was not clearing its assigned cell during disconnection
- mac was not clearing sync info during disconnection
- association module was continuing backoff even after synced gateway got full

