### PR TITLE
WIP: debugging Mira with 101 nodes and 1 gateway

### DIFF
--- a/app/03app_node/board.c
+++ b/app/03app_node/board.c
@@ -96,5 +96,6 @@ void board_set_led_app(led_color_t color) {
     }
 #endif
 #ifdef MIRA_BOARD_MINIMOTE
+    (void)color;
 #endif
 }

--- a/mira-node-dotbot-v2.emProject
+++ b/mira-node-dotbot-v2.emProject
@@ -40,7 +40,7 @@
     link_time_optimization="No"
     linker_additional_options="--gc-sections"
     linker_memory_map_file="$(ProjectDir)/../../nRF/Setup/nRF5340_xxAA_Network_MemoryMap.xml"
-    linker_output_format="bin"
+    linker_output_format="hex"
     linker_printf_fmt_level="int"
     linker_printf_fp_enabled="Float"
     linker_printf_width_precision_supported="Yes"

--- a/mira-node-nrf52840dk.emProject
+++ b/mira-node-nrf52840dk.emProject
@@ -45,7 +45,7 @@
     link_time_optimization="No"
     linker_additional_options="--gc-sections"
     linker_memory_map_file="$(ProjectDir)/../../nRF/Setup/nRF52840_xxAA_MemoryMap.xml"
-    linker_output_format="bin"
+    linker_output_format="hex"
     linker_printf_fmt_level="int"
     linker_printf_fp_enabled="Float"
     linker_printf_width_precision_supported="Yes"

--- a/mira/mira.c
+++ b/mira/mira.c
@@ -120,14 +120,12 @@ void mr_handle_packet(uint8_t *packet, uint8_t length) {
                     return;
                 }
                 // try to assign a cell to the node
-                int16_t cell_id = mr_scheduler_gateway_assign_next_available_uplink_cell(header->src, mr_mac_get_asn());  // the asn-based keep-alive is also initialized
+                // the asn-based keep-alive is also initialized, so no need to call mr_assoc_gateway_keep_node_alive
+                int16_t cell_id = mr_scheduler_gateway_assign_next_available_uplink_cell(header->src, mr_mac_get_asn());
                 if (cell_id >= 0) {
                     // at the packet level, max_nodes is limited to 256 (using uint8_t cell_id)
                     mr_queue_set_join_response(header->src, (uint8_t)cell_id);
-                    // having an updated bloom filter ASAP is important, because otherwise
-                    // the node might receive an outdated bloom and think it's already left the gateway.
-                    // hence we compute it immediately instead of just setting the dirty flag
-                    mr_bloom_gateway_compute();
+                    mr_bloom_gateway_set_dirty();
                     _mira_vars.app_event_callback(MIRA_NODE_JOINED, (mr_event_data_t){ .data.node_info.node_id = header->src });
                 } else {
                     _mira_vars.app_event_callback(MIRA_ERROR, (mr_event_data_t){ .tag = MIRA_GATEWAY_FULL });


### PR DESCRIPTION
It works with 101 nodes, but is still somehow unstable. For more details see #118 

This PR is currently very messy, it serves more as a place to save my debugging state as of today. 

Here is what we should probably keep from this PR:
- move `mira_event_loop` to the main loop (and not use it in a recurrent timer)

- use `MIRA_JOINED_GRACE_NON_LEAVE_PERIOD` (maybe?)
```diff
+    uint32_t now_ts = mr_timer_hf_now(MIRA_TIMER_DEV);
+    if (now_ts - assoc_vars.last_state_change_ts < MIRA_JOINED_GRACE_NON_LEAVE_PERIOD) {
+        // if the node just recently joined, do not leave
+        return false;
+    }
```

- do NOT update the bloom filter during JoinRequest handling inside the slot interrupt:
```diff
-                    // having an updated bloom filter ASAP is important, because otherwise
-                    // the node might receive an outdated bloom and think it's already left the gateway.
-                    // hence we compute it immediately instead of just setting the dirty flag
-                    mr_bloom_gateway_compute();
+                    mr_bloom_gateway_set_dirty();
```