### PR TITLE
mari: header next_proto field + handler registration + typed sender API

### DIFF
--- a/firmware/app/01mari_maclow/main.c
+++ b/firmware/app/01mari_maclow/main.c
@@ -102,7 +102,7 @@ void mari_event_callback(mr_event_t event, mr_event_data_t event_data) {
             uint8_t packet[MARI_PACKET_MAX_SIZE] = { 0 };
             uint8_t data[]                       = { 0x48, 0x65, 0x6C, 0x6C, 0x6F };  // "Hello"
 
-            uint8_t packet_len = mr_build_packet_data(packet, event_data.data.gateway_info.gateway_id, MARI_NEXT_PROTO_MARI_INTERNAL, data, 5);
+            uint8_t packet_len = mr_build_packet_data(packet, event_data.data.gateway_info.gateway_id, &MARI_TX_INTERNAL, data, 5);
 
             mr_queue_add(packet, packet_len);
             mr_queue_add(packet, packet_len);

--- a/firmware/app/01mari_maclow/main.c
+++ b/firmware/app/01mari_maclow/main.c
@@ -102,7 +102,7 @@ void mari_event_callback(mr_event_t event, mr_event_data_t event_data) {
             uint8_t packet[MARI_PACKET_MAX_SIZE] = { 0 };
             uint8_t data[]                       = { 0x48, 0x65, 0x6C, 0x6C, 0x6F };  // "Hello"
 
-            uint8_t packet_len = mr_build_packet_data(packet, event_data.data.gateway_info.gateway_id, data, 5);
+            uint8_t packet_len = mr_build_packet_data(packet, event_data.data.gateway_info.gateway_id, MARI_NEXT_PROTO_MARI_INTERNAL, data, 5);
 
             mr_queue_add(packet, packet_len);
             mr_queue_add(packet, packet_len);

--- a/firmware/app/01mari_maclow/main.c
+++ b/firmware/app/01mari_maclow/main.c
@@ -102,7 +102,7 @@ void mari_event_callback(mr_event_t event, mr_event_data_t event_data) {
             uint8_t packet[MARI_PACKET_MAX_SIZE] = { 0 };
             uint8_t data[]                       = { 0x48, 0x65, 0x6C, 0x6C, 0x6F };  // "Hello"
 
-            uint8_t packet_len = mr_build_packet_data(packet, event_data.data.gateway_info.gateway_id, &MARI_TX_INTERNAL, data, 5);
+            uint8_t packet_len = mr_build_packet_data(packet, event_data.data.gateway_info.gateway_id, data, 5, &MARI_TX_INTERNAL);
 
             mr_queue_add(packet, packet_len);
             mr_queue_add(packet, packet_len);

--- a/firmware/app/03app_gateway_test/main.c
+++ b/firmware/app/03app_gateway_test/main.c
@@ -108,7 +108,7 @@ void tx_to_all_connected(void) {
     for (int i = 0; i < nodes_len; i++) {
         // printf("Enqueing TX to node %d: %016llX\n", i, nodes[i]);
         payload[0]         = i;
-        uint8_t packet_len = mr_build_packet_data(packet, nodes[i], payload, payload_len);
+        uint8_t packet_len = mr_build_packet_data(packet, nodes[i], MARI_NEXT_PROTO_MARI_INTERNAL, payload, payload_len);
         mari_tx(packet, packet_len);
         stats_register('D');
     }

--- a/firmware/app/03app_gateway_test/main.c
+++ b/firmware/app/03app_gateway_test/main.c
@@ -108,7 +108,7 @@ void tx_to_all_connected(void) {
     for (int i = 0; i < nodes_len; i++) {
         // printf("Enqueing TX to node %d: %016llX\n", i, nodes[i]);
         payload[0]         = i;
-        uint8_t packet_len = mr_build_packet_data(packet, nodes[i], &MARI_TX_INTERNAL, payload, payload_len);
+        uint8_t packet_len = mr_build_packet_data(packet, nodes[i], payload, payload_len, &MARI_TX_INTERNAL);
         mari_tx(packet, packet_len);
         stats_register('D');
     }

--- a/firmware/app/03app_gateway_test/main.c
+++ b/firmware/app/03app_gateway_test/main.c
@@ -108,7 +108,7 @@ void tx_to_all_connected(void) {
     for (int i = 0; i < nodes_len; i++) {
         // printf("Enqueing TX to node %d: %016llX\n", i, nodes[i]);
         payload[0]         = i;
-        uint8_t packet_len = mr_build_packet_data(packet, nodes[i], MARI_NEXT_PROTO_MARI_INTERNAL, payload, payload_len);
+        uint8_t packet_len = mr_build_packet_data(packet, nodes[i], &MARI_TX_INTERNAL, payload, payload_len);
         mari_tx(packet, packet_len);
         stats_register('D');
     }

--- a/firmware/app/03app_node/main.c
+++ b/firmware/app/03app_node/main.c
@@ -164,7 +164,7 @@ int main(void) {
 
         if (node_vars.send_status_ready) {
             node_vars.send_status_ready = false;
-            mari_node_tx_payload((uint8_t *)status_packet_mock, sizeof(status_packet_mock));
+            mari_node_tx_payload((uint8_t *)status_packet_mock, sizeof(status_packet_mock), MARI_NEXT_PROTO_MARI_INTERNAL);
         }
 
         mari_event_loop();

--- a/firmware/app/03app_node/main.c
+++ b/firmware/app/03app_node/main.c
@@ -93,7 +93,7 @@ static void handle_metrics_payload(mr_metrics_payload_t *metrics_payload) {
     metrics_payload->rssi_at_node         = mr_radio_rssi();
 
     // send metrics probe to gateway
-    mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t), MARI_NEXT_PROTO_MARI_INTERNAL);
+    mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t), &MARI_TX_INTERNAL);
 }
 
 static void _send_status_packet_callback(void) {
@@ -164,7 +164,7 @@ int main(void) {
 
         if (node_vars.send_status_ready) {
             node_vars.send_status_ready = false;
-            mari_node_tx_payload((uint8_t *)status_packet_mock, sizeof(status_packet_mock), MARI_NEXT_PROTO_MARI_INTERNAL);
+            mari_node_tx_payload((uint8_t *)status_packet_mock, sizeof(status_packet_mock), &MARI_TX_INTERNAL);
         }
 
         mari_event_loop();

--- a/firmware/app/03app_node/main.c
+++ b/firmware/app/03app_node/main.c
@@ -93,7 +93,7 @@ static void handle_metrics_payload(mr_metrics_payload_t *metrics_payload) {
     metrics_payload->rssi_at_node         = mr_radio_rssi();
 
     // send metrics probe to gateway
-    mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t));
+    mari_node_tx_payload((uint8_t *)metrics_payload, sizeof(mr_metrics_payload_t), MARI_NEXT_PROTO_MARI_INTERNAL);
 }
 
 static void _send_status_packet_callback(void) {

--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -600,13 +600,14 @@ static void activity_ri4(uint32_t ts) {
         fix_drift(mac_vars.received_packet.start_ts);
     }
 
-    // now that we know it's a mari packet, store some info about it
+    // now that we know it's a mari packet, store some info about it.
+    // RSSI is kept in mac_vars.received_packet.rssi for local handover
+    // logic; per-frame RSSI is no longer carried in the wire header (use
+    // MetricsProbePayload.rssi_at_{node,gw} for host-side reporting).
     mac_vars.received_packet.channel = mac_vars.current_slot_info.channel;
     mac_vars.received_packet.rssi    = mr_radio_rssi();
     mac_vars.received_packet.end_ts  = ts;
     mac_vars.received_packet.asn     = mac_vars.asn;
-
-    header->stats.rssi = mr_radio_rssi();
 
     mr_handle_packet(mac_vars.received_packet.packet, mac_vars.received_packet.packet_len);
 

--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -600,10 +600,8 @@ static void activity_ri4(uint32_t ts) {
         fix_drift(mac_vars.received_packet.start_ts);
     }
 
-    // now that we know it's a mari packet, store some info about it.
-    // RSSI is kept in mac_vars.received_packet.rssi for local handover
-    // logic; per-frame RSSI is no longer carried in the wire header (use
-    // MetricsProbePayload.rssi_at_{node,gw} for host-side reporting).
+    // store info about the received packet; rssi is used by the handover
+    // hysteresis check below
     mac_vars.received_packet.channel = mac_vars.current_slot_info.channel;
     mac_vars.received_packet.rssi    = mr_radio_rssi();
     mac_vars.received_packet.end_ts  = ts;

--- a/firmware/mari/mari.c
+++ b/firmware/mari/mari.c
@@ -94,9 +94,9 @@ size_t mari_gateway_count_nodes(void) {
 
 // -------- node ----------
 
-void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, mr_next_proto_t next_proto) {
+void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, const mari_tx_config_t *cfg) {
     uint8_t packet[MARI_PACKET_MAX_SIZE] = { 0 };
-    uint8_t len                          = mr_build_packet_data(packet, mari_node_gateway_id(), next_proto, payload, payload_len);
+    uint8_t len                          = mr_build_packet_data(packet, mari_node_gateway_id(), cfg, payload, payload_len);
     mr_queue_add(packet, len);
 }
 

--- a/firmware/mari/mari.c
+++ b/firmware/mari/mari.c
@@ -94,9 +94,9 @@ size_t mari_gateway_count_nodes(void) {
 
 // -------- node ----------
 
-void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len) {
+void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, mr_next_proto_t next_proto) {
     uint8_t packet[MARI_PACKET_MAX_SIZE] = { 0 };
-    uint8_t len                          = mr_build_packet_data(packet, mari_node_gateway_id(), payload, payload_len);
+    uint8_t len                          = mr_build_packet_data(packet, mari_node_gateway_id(), next_proto, payload, payload_len);
     mr_queue_add(packet, len);
 }
 

--- a/firmware/mari/mari.c
+++ b/firmware/mari/mari.c
@@ -96,7 +96,7 @@ size_t mari_gateway_count_nodes(void) {
 
 void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, const mari_tx_config_t *cfg) {
     uint8_t packet[MARI_PACKET_MAX_SIZE] = { 0 };
-    uint8_t len                          = mr_build_packet_data(packet, mari_node_gateway_id(), cfg, payload, payload_len);
+    uint8_t len                          = mr_build_packet_data(packet, mari_node_gateway_id(), payload, payload_len, cfg);
     mr_queue_add(packet, len);
 }
 

--- a/firmware/mari/mari.h
+++ b/firmware/mari/mari.h
@@ -32,7 +32,14 @@ void           mari_set_node_type(mr_node_type_t node_type);
 size_t mari_gateway_get_nodes(uint64_t *nodes);
 size_t mari_gateway_count_nodes(void);
 
-void     mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, mr_next_proto_t next_proto);
+void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, const mari_tx_config_t *cfg);
+
+// Default config for mari's own internal traffic (metrics, control). Other
+// consumers (DotBot apps, SwarmIT, IP stacks) define their own mari_tx_config_t
+// constants — pattern documented in models.h.
+static const mari_tx_config_t MARI_TX_INTERNAL = {
+    .next_proto = MARI_NEXT_PROTO_MARI_INTERNAL,
+};
 bool     mari_node_is_connected(void);
 uint64_t mari_node_gateway_id(void);
 

--- a/firmware/mari/mari.h
+++ b/firmware/mari/mari.h
@@ -32,14 +32,7 @@ void           mari_set_node_type(mr_node_type_t node_type);
 size_t mari_gateway_get_nodes(uint64_t *nodes);
 size_t mari_gateway_count_nodes(void);
 
-void mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, const mari_tx_config_t *cfg);
-
-// Default config for mari's own internal traffic (metrics, control). Other
-// consumers (DotBot apps, SwarmIT, IP stacks) define their own mari_tx_config_t
-// constants — pattern documented in models.h.
-static const mari_tx_config_t MARI_TX_INTERNAL = {
-    .next_proto = MARI_NEXT_PROTO_MARI_INTERNAL,
-};
+void     mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, const mari_tx_config_t *cfg);
 bool     mari_node_is_connected(void);
 uint64_t mari_node_gateway_id(void);
 

--- a/firmware/mari/mari.h
+++ b/firmware/mari/mari.h
@@ -32,7 +32,7 @@ void           mari_set_node_type(mr_node_type_t node_type);
 size_t mari_gateway_get_nodes(uint64_t *nodes);
 size_t mari_gateway_count_nodes(void);
 
-void     mari_node_tx_payload(uint8_t *payload, uint8_t payload_len);
+void     mari_node_tx_payload(uint8_t *payload, uint8_t payload_len, mr_next_proto_t next_proto);
 bool     mari_node_is_connected(void);
 uint64_t mari_node_gateway_id(void);
 

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -56,15 +56,34 @@ typedef enum {
 // MARI_PACKET_{BEACON,JOIN_*,KEEPALIVE} the field is always
 // MARI_NEXT_PROTO_MARI_INTERNAL — those frames are mari-managed by
 // definition.
+//
+// Numeric layout — high nibble names a category, low nibble names an
+// item within that category. 16 × 16 = 256 slots total.
+//   0x00         reserved (null catcher)
+//   0x01..0x0F   mari link-layer internal (metrics, control, …)
+//   0x10..0x1F   swarm-application protocols (DotBot, SwarmIT, …)
+//   0x20..0x2F   standardized network protocols (IPv4, IPv6, ARP, …)
+//   0x30..0xEF   reserved for future categories
+//   0xF0..0xFE   experimental / private use
+//   0xFF         reserved
 typedef enum {
-    MARI_NEXT_PROTO_RESERVED        = 0,     // catches uninitialized memory
-    MARI_NEXT_PROTO_MARI_INTERNAL   = 1,     // default; mari's own control + metrics
-    MARI_NEXT_PROTO_DOTBOT_APP      = 2,     // DotBot application protocol
-    MARI_NEXT_PROTO_SWARMIT_TESTBED = 3,     // SwarmIT testbed protocol
-    MARI_NEXT_PROTO_IPV4            = 4,     // IPv4 packet (RFC 791)
-    MARI_NEXT_PROTO_IPV6            = 5,     // IPv6 packet (RFC 8200)
+    MARI_NEXT_PROTO_RESERVED        = 0x00,  // catches uninitialized memory
+    MARI_NEXT_PROTO_MARI_INTERNAL   = 0x01,  // default; mari's own control + metrics
+    MARI_NEXT_PROTO_DOTBOT_APP      = 0x10,  // DotBot application protocol
+    MARI_NEXT_PROTO_SWARMIT_TESTBED = 0x11,  // SwarmIT testbed protocol
+    MARI_NEXT_PROTO_IPV4            = 0x21,  // IPv4 packet (RFC 791)
+    MARI_NEXT_PROTO_IPV6            = 0x22,  // IPv6 packet (RFC 8200)
     MARI_NEXT_PROTO_EXPERIMENTAL    = 0xFE,  // experimental / private use
 } mr_next_proto_t;
+
+// Per-frame send configuration. Passed by pointer to the sender API so
+// new fields can be added without breaking call sites — pattern borrowed
+// from Linux sendmsg(2), Zephyr net_pkt, OpenThread otMessageSettings.
+// Future fields likely to land here: priority, retry policy, TTL in
+// slotframes, request for link-layer security, …
+typedef struct {
+    mr_next_proto_t next_proto;
+} mari_tx_config_t;
 
 // general packet header
 typedef struct __attribute__((packed)) {

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -50,6 +50,22 @@ typedef enum {
     MARI_PACKET_DATA          = 16,
 } mr_packet_type_t;
 
+// Upper-layer protocol multiplex (EtherType / PPP Protocol / IPv6 Next
+// Header analogue). Meaningful when type == MARI_PACKET_DATA; receivers
+// dispatch the payload to the owner of the indicated namespace. For
+// MARI_PACKET_{BEACON,JOIN_*,KEEPALIVE} the field is always
+// MARI_NEXT_PROTO_MARI_INTERNAL — those frames are mari-managed by
+// definition.
+typedef enum {
+    MARI_NEXT_PROTO_RESERVED        = 0,    // catches uninitialized memory
+    MARI_NEXT_PROTO_MARI_INTERNAL   = 1,    // default; mari's own control + metrics
+    MARI_NEXT_PROTO_DOTBOT_APP      = 2,    // DotBot application protocol
+    MARI_NEXT_PROTO_SWARMIT_TESTBED = 3,    // SwarmIT testbed protocol
+    MARI_NEXT_PROTO_IPV4            = 4,    // IPv4 packet (RFC 791)
+    MARI_NEXT_PROTO_IPV6            = 5,    // IPv6 packet (RFC 8200)
+    MARI_NEXT_PROTO_EXPERIMENTAL    = 0xFE, // experimental / private use
+} mr_next_proto_t;
+
 // general packet header
 typedef struct __attribute__((packed)) {
     uint8_t          version;
@@ -57,6 +73,7 @@ typedef struct __attribute__((packed)) {
     uint16_t         network_id;
     uint64_t         dst;
     uint64_t         src;
+    mr_next_proto_t  next_proto;
 } mr_packet_header_t;
 
 // beacon packet

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -57,23 +57,22 @@ typedef enum {
 // MARI_NEXT_PROTO_MARI_INTERNAL — those frames are mari-managed by
 // definition.
 //
-// Numeric layout — high nibble names a category, low nibble names an
-// item within that category. 16 × 16 = 256 slots total.
-//   0x00         unknown / unspecified (null catcher, also default for null cfg)
-//   0x01..0x0F   mari link-layer internal (metrics, control, …)
-//   0x10..0x1F   swarm-application protocols (DotBot, SwarmIT, …)
-//   0x20..0x2F   standardized network protocols (IPv4, IPv6, ARP, …)
-//   0x30..0xEF   reserved for future categories
-//   0xF0..0xFE   experimental / private use
-//   0xFF         reserved
 typedef enum {
-    MARI_NEXT_PROTO_UNKNOWN         = 0x00,  // null cfg / uninitialized / sender didn't say
-    MARI_NEXT_PROTO_MARI_INTERNAL   = 0x01,  // mari's own control + metrics
-    MARI_NEXT_PROTO_DOTBOT_APP      = 0x10,  // DotBot application protocol
-    MARI_NEXT_PROTO_SWARMIT_TESTBED = 0x11,  // SwarmIT testbed protocol
-    MARI_NEXT_PROTO_IPV4            = 0x21,  // IPv4 packet (RFC 791)
-    MARI_NEXT_PROTO_IPV6            = 0x22,  // IPv6 packet (RFC 8200)
-    MARI_NEXT_PROTO_EXPERIMENTAL    = 0xFE,  // experimental / private use
+    MARI_NEXT_PROTO_RESERVED = 0x00,  // null catcher / null cfg default
+
+    MARI_NEXT_PROTO_MARI_INTERNAL = 0x01,  // mari's own control + metrics
+    // 0x02..0x09 reserved for mari extensions
+
+    MARI_NEXT_PROTO_SWARMIT_TESTBED = 0x10,  // SwarmIT testbed protocol
+    MARI_NEXT_PROTO_DOTBOT_APP      = 0x11,  // DotBot application protocol
+    // 0x12..0x39 reserved for custom app protocols
+
+    MARI_NEXT_PROTO_IPV4 = 0xA0,  // IPv4 packet (RFC 791)
+    MARI_NEXT_PROTO_IPV6 = 0xA1,  // IPv6 packet (RFC 8200)
+    // 0xA2..0xFD reserved for standardized network protocols
+
+    MARI_NEXT_PROTO_EXPERIMENTAL = 0xFE,  // experimental / private use
+    // 0xFF reserved (high sentinel)
 } mr_next_proto_t;
 
 // Per-frame send configuration. Passed by pointer to the sender API so

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -59,7 +59,7 @@ typedef enum {
 //
 // Numeric layout — high nibble names a category, low nibble names an
 // item within that category. 16 × 16 = 256 slots total.
-//   0x00         reserved (null catcher)
+//   0x00         unknown / unspecified (null catcher, also default for null cfg)
 //   0x01..0x0F   mari link-layer internal (metrics, control, …)
 //   0x10..0x1F   swarm-application protocols (DotBot, SwarmIT, …)
 //   0x20..0x2F   standardized network protocols (IPv4, IPv6, ARP, …)
@@ -67,8 +67,8 @@ typedef enum {
 //   0xF0..0xFE   experimental / private use
 //   0xFF         reserved
 typedef enum {
-    MARI_NEXT_PROTO_RESERVED        = 0x00,  // catches uninitialized memory
-    MARI_NEXT_PROTO_MARI_INTERNAL   = 0x01,  // default; mari's own control + metrics
+    MARI_NEXT_PROTO_UNKNOWN         = 0x00,  // null cfg / uninitialized / sender didn't say
+    MARI_NEXT_PROTO_MARI_INTERNAL   = 0x01,  // mari's own control + metrics
     MARI_NEXT_PROTO_DOTBOT_APP      = 0x10,  // DotBot application protocol
     MARI_NEXT_PROTO_SWARMIT_TESTBED = 0x11,  // SwarmIT testbed protocol
     MARI_NEXT_PROTO_IPV4            = 0x21,  // IPv4 packet (RFC 791)

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -85,6 +85,13 @@ typedef struct {
     mr_next_proto_t next_proto;
 } mari_tx_config_t;
 
+// Default config for mari's own internal traffic (metrics, control). Other
+// consumers (DotBot apps, SwarmIT, IP stacks) define their own mari_tx_config_t
+// constants per the high-nibble category partition above.
+static const mari_tx_config_t MARI_TX_INTERNAL = {
+    .next_proto = MARI_NEXT_PROTO_MARI_INTERNAL,
+};
+
 // general packet header
 typedef struct __attribute__((packed)) {
     uint8_t          version;

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -50,18 +50,13 @@ typedef enum {
     MARI_PACKET_DATA          = 16,
 } mr_packet_type_t;
 
-typedef struct __attribute__((packed)) {
-    int8_t rssi;
-} mr_packet_statistics_t;
-
 // general packet header
 typedef struct __attribute__((packed)) {
-    uint8_t                version;
-    mr_packet_type_t       type;
-    uint16_t               network_id;
-    uint64_t               dst;
-    uint64_t               src;
-    mr_packet_statistics_t stats;
+    uint8_t          version;
+    mr_packet_type_t type;
+    uint16_t         network_id;
+    uint64_t         dst;
+    uint64_t         src;
 } mr_packet_header_t;
 
 // beacon packet

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -57,13 +57,13 @@ typedef enum {
 // MARI_NEXT_PROTO_MARI_INTERNAL — those frames are mari-managed by
 // definition.
 typedef enum {
-    MARI_NEXT_PROTO_RESERVED        = 0,    // catches uninitialized memory
-    MARI_NEXT_PROTO_MARI_INTERNAL   = 1,    // default; mari's own control + metrics
-    MARI_NEXT_PROTO_DOTBOT_APP      = 2,    // DotBot application protocol
-    MARI_NEXT_PROTO_SWARMIT_TESTBED = 3,    // SwarmIT testbed protocol
-    MARI_NEXT_PROTO_IPV4            = 4,    // IPv4 packet (RFC 791)
-    MARI_NEXT_PROTO_IPV6            = 5,    // IPv6 packet (RFC 8200)
-    MARI_NEXT_PROTO_EXPERIMENTAL    = 0xFE, // experimental / private use
+    MARI_NEXT_PROTO_RESERVED        = 0,     // catches uninitialized memory
+    MARI_NEXT_PROTO_MARI_INTERNAL   = 1,     // default; mari's own control + metrics
+    MARI_NEXT_PROTO_DOTBOT_APP      = 2,     // DotBot application protocol
+    MARI_NEXT_PROTO_SWARMIT_TESTBED = 3,     // SwarmIT testbed protocol
+    MARI_NEXT_PROTO_IPV4            = 4,     // IPv4 packet (RFC 791)
+    MARI_NEXT_PROTO_IPV6            = 5,     // IPv6 packet (RFC 8200)
+    MARI_NEXT_PROTO_EXPERIMENTAL    = 0xFE,  // experimental / private use
 } mr_next_proto_t;
 
 // general packet header

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -71,12 +71,17 @@ size_t mr_build_uart_packet_gateway_info(uint8_t *buffer) {
 static size_t _set_header(uint8_t *buffer, uint64_t dst, mr_packet_type_t packet_type) {
     uint64_t src = mr_device_id();
 
+    // next_proto defaults to MARI_INTERNAL. Upper-layer senders (DotBot,
+    // SwarmIT, future IP stacks) will override via a typed send API once
+    // the protocol-repo work lands; for now every send is labeled as
+    // mari-managed, matching today's de-facto behavior.
     mr_packet_header_t header = {
         .version    = MARI_PROTOCOL_VERSION,
         .type       = packet_type,
         .network_id = mr_assoc_get_network_id(),
         .dst        = dst,
         .src        = src,
+        .next_proto = MARI_NEXT_PROTO_MARI_INTERNAL,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -25,9 +25,9 @@ static size_t _set_header(uint8_t                *buffer,
 
 size_t mr_build_packet_data(uint8_t                *buffer,
                             uint64_t                dst,
-                            const mari_tx_config_t *cfg,
                             uint8_t                *data,
-                            size_t                  data_len) {
+                            size_t                  data_len,
+                            const mari_tx_config_t *cfg) {
     size_t header_len = _set_header(buffer, dst, MARI_PACKET_DATA, cfg);
     memcpy(buffer + header_len, data, data_len);
     return header_len + data_len;
@@ -81,13 +81,17 @@ static size_t _set_header(uint8_t                *buffer,
                           const mari_tx_config_t *cfg) {
     uint64_t src = mr_device_id();
 
+    // Null cfg → MARI_NEXT_PROTO_UNKNOWN (0). Same outcome as cfg with
+    // next_proto explicitly 0 — receivers can't tell the cases apart,
+    // and neither can the wire. Senders that want their traffic
+    // identified must pass a non-null cfg with next_proto set.
     mr_packet_header_t header = {
         .version    = MARI_PROTOCOL_VERSION,
         .type       = packet_type,
         .network_id = mr_assoc_get_network_id(),
         .dst        = dst,
         .src        = src,
-        .next_proto = cfg->next_proto,
+        .next_proto = cfg ? cfg->next_proto : MARI_NEXT_PROTO_UNKNOWN,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -16,33 +16,33 @@
 
 //=========================== prototypes =======================================
 
-static size_t _set_header(uint8_t         *buffer,
-                          uint64_t         dst,
-                          mr_packet_type_t packet_type,
-                          mr_next_proto_t  next_proto);
+static size_t _set_header(uint8_t                *buffer,
+                          uint64_t                dst,
+                          mr_packet_type_t        packet_type,
+                          const mari_tx_config_t *cfg);
 
 //=========================== public ===========================================
 
-size_t mr_build_packet_data(uint8_t        *buffer,
-                            uint64_t        dst,
-                            mr_next_proto_t next_proto,
-                            uint8_t        *data,
-                            size_t          data_len) {
-    size_t header_len = _set_header(buffer, dst, MARI_PACKET_DATA, next_proto);
+size_t mr_build_packet_data(uint8_t                *buffer,
+                            uint64_t                dst,
+                            const mari_tx_config_t *cfg,
+                            uint8_t                *data,
+                            size_t                  data_len) {
+    size_t header_len = _set_header(buffer, dst, MARI_PACKET_DATA, cfg);
     memcpy(buffer + header_len, data, data_len);
     return header_len + data_len;
 }
 
 size_t mr_build_packet_keepalive(uint8_t *buffer, uint64_t dst) {
-    return _set_header(buffer, dst, MARI_PACKET_KEEPALIVE, MARI_NEXT_PROTO_MARI_INTERNAL);
+    return _set_header(buffer, dst, MARI_PACKET_KEEPALIVE, &MARI_TX_INTERNAL);
 }
 
 size_t mr_build_packet_join_request(uint8_t *buffer, uint64_t dst) {
-    return _set_header(buffer, dst, MARI_PACKET_JOIN_REQUEST, MARI_NEXT_PROTO_MARI_INTERNAL);
+    return _set_header(buffer, dst, MARI_PACKET_JOIN_REQUEST, &MARI_TX_INTERNAL);
 }
 
 size_t mr_build_packet_join_response(uint8_t *buffer, uint64_t dst) {
-    return _set_header(buffer, dst, MARI_PACKET_JOIN_RESPONSE, MARI_NEXT_PROTO_MARI_INTERNAL);
+    return _set_header(buffer, dst, MARI_PACKET_JOIN_RESPONSE, &MARI_TX_INTERNAL);
 }
 
 size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, uint8_t remaining_capacity, uint8_t active_schedule_id) {
@@ -75,10 +75,10 @@ size_t mr_build_uart_packet_gateway_info(uint8_t *buffer) {
 
 //=========================== private ==========================================
 
-static size_t _set_header(uint8_t         *buffer,
-                          uint64_t         dst,
-                          mr_packet_type_t packet_type,
-                          mr_next_proto_t  next_proto) {
+static size_t _set_header(uint8_t                *buffer,
+                          uint64_t                dst,
+                          mr_packet_type_t        packet_type,
+                          const mari_tx_config_t *cfg) {
     uint64_t src = mr_device_id();
 
     mr_packet_header_t header = {
@@ -87,7 +87,7 @@ static size_t _set_header(uint8_t         *buffer,
         .network_id = mr_assoc_get_network_id(),
         .dst        = dst,
         .src        = src,
-        .next_proto = next_proto,
+        .next_proto = cfg->next_proto,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -81,17 +81,16 @@ static size_t _set_header(uint8_t                *buffer,
                           const mari_tx_config_t *cfg) {
     uint64_t src = mr_device_id();
 
-    // Null cfg → MARI_NEXT_PROTO_UNKNOWN (0). Same outcome as cfg with
-    // next_proto explicitly 0 — receivers can't tell the cases apart,
-    // and neither can the wire. Senders that want their traffic
-    // identified must pass a non-null cfg with next_proto set.
+    // Null cfg → MARI_NEXT_PROTO_RESERVED (0). Same outcome as cfg with
+    // next_proto explicitly 0. Senders that want their traffic labeled
+    // must pass a non-null cfg with next_proto set.
     mr_packet_header_t header = {
         .version    = MARI_PROTOCOL_VERSION,
         .type       = packet_type,
         .network_id = mr_assoc_get_network_id(),
         .dst        = dst,
         .src        = src,
-        .next_proto = cfg ? cfg->next_proto : MARI_NEXT_PROTO_UNKNOWN,
+        .next_proto = cfg ? cfg->next_proto : MARI_NEXT_PROTO_RESERVED,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -16,26 +16,33 @@
 
 //=========================== prototypes =======================================
 
-static size_t _set_header(uint8_t *buffer, uint64_t dst, mr_packet_type_t packet_type);
+static size_t _set_header(uint8_t         *buffer,
+                          uint64_t         dst,
+                          mr_packet_type_t packet_type,
+                          mr_next_proto_t  next_proto);
 
 //=========================== public ===========================================
 
-size_t mr_build_packet_data(uint8_t *buffer, uint64_t dst, uint8_t *data, size_t data_len) {
-    size_t header_len = _set_header(buffer, dst, MARI_PACKET_DATA);
+size_t mr_build_packet_data(uint8_t        *buffer,
+                            uint64_t        dst,
+                            mr_next_proto_t next_proto,
+                            uint8_t        *data,
+                            size_t          data_len) {
+    size_t header_len = _set_header(buffer, dst, MARI_PACKET_DATA, next_proto);
     memcpy(buffer + header_len, data, data_len);
     return header_len + data_len;
 }
 
 size_t mr_build_packet_keepalive(uint8_t *buffer, uint64_t dst) {
-    return _set_header(buffer, dst, MARI_PACKET_KEEPALIVE);
+    return _set_header(buffer, dst, MARI_PACKET_KEEPALIVE, MARI_NEXT_PROTO_MARI_INTERNAL);
 }
 
 size_t mr_build_packet_join_request(uint8_t *buffer, uint64_t dst) {
-    return _set_header(buffer, dst, MARI_PACKET_JOIN_REQUEST);
+    return _set_header(buffer, dst, MARI_PACKET_JOIN_REQUEST, MARI_NEXT_PROTO_MARI_INTERNAL);
 }
 
 size_t mr_build_packet_join_response(uint8_t *buffer, uint64_t dst) {
-    return _set_header(buffer, dst, MARI_PACKET_JOIN_RESPONSE);
+    return _set_header(buffer, dst, MARI_PACKET_JOIN_RESPONSE, MARI_NEXT_PROTO_MARI_INTERNAL);
 }
 
 size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, uint8_t remaining_capacity, uint8_t active_schedule_id) {
@@ -68,20 +75,19 @@ size_t mr_build_uart_packet_gateway_info(uint8_t *buffer) {
 
 //=========================== private ==========================================
 
-static size_t _set_header(uint8_t *buffer, uint64_t dst, mr_packet_type_t packet_type) {
+static size_t _set_header(uint8_t         *buffer,
+                          uint64_t         dst,
+                          mr_packet_type_t packet_type,
+                          mr_next_proto_t  next_proto) {
     uint64_t src = mr_device_id();
 
-    // next_proto defaults to MARI_INTERNAL. Upper-layer senders (DotBot,
-    // SwarmIT, future IP stacks) will override via a typed send API once
-    // the protocol-repo work lands; for now every send is labeled as
-    // mari-managed, matching today's de-facto behavior.
     mr_packet_header_t header = {
         .version    = MARI_PROTOCOL_VERSION,
         .type       = packet_type,
         .network_id = mr_assoc_get_network_id(),
         .dst        = dst,
         .src        = src,
-        .next_proto = MARI_NEXT_PROTO_MARI_INTERNAL,
+        .next_proto = next_proto,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/firmware/mari/packet.h
+++ b/firmware/mari/packet.h
@@ -30,9 +30,9 @@
 
 size_t mr_build_packet_data(uint8_t                *buffer,
                             uint64_t                dst,
-                            const mari_tx_config_t *cfg,
                             uint8_t                *data,
-                            size_t                  data_len);
+                            size_t                  data_len,
+                            const mari_tx_config_t *cfg);
 
 size_t mr_build_packet_join_request(uint8_t *buffer, uint64_t dst);
 

--- a/firmware/mari/packet.h
+++ b/firmware/mari/packet.h
@@ -28,11 +28,11 @@
 
 //=========================== prototypes =======================================
 
-size_t mr_build_packet_data(uint8_t        *buffer,
-                            uint64_t        dst,
-                            mr_next_proto_t next_proto,
-                            uint8_t        *data,
-                            size_t          data_len);
+size_t mr_build_packet_data(uint8_t                *buffer,
+                            uint64_t                dst,
+                            const mari_tx_config_t *cfg,
+                            uint8_t                *data,
+                            size_t                  data_len);
 
 size_t mr_build_packet_join_request(uint8_t *buffer, uint64_t dst);
 

--- a/firmware/mari/packet.h
+++ b/firmware/mari/packet.h
@@ -28,7 +28,11 @@
 
 //=========================== prototypes =======================================
 
-size_t mr_build_packet_data(uint8_t *buffer, uint64_t dst, uint8_t *data, size_t data_len);
+size_t mr_build_packet_data(uint8_t        *buffer,
+                            uint64_t        dst,
+                            mr_next_proto_t next_proto,
+                            uint8_t        *data,
+                            size_t          data_len);
 
 size_t mr_build_packet_join_request(uint8_t *buffer, uint64_t dst);
 

--- a/firmware/mari/packet.h
+++ b/firmware/mari/packet.h
@@ -21,7 +21,7 @@
 
 //=========================== defines ==========================================
 
-#define MARI_PROTOCOL_VERSION 2
+#define MARI_PROTOCOL_VERSION 3
 
 #define MARI_NET_ID_PATTERN_ANY 0
 #define MARI_NET_ID_DEFAULT     1

--- a/marilib/examples/mari_cloud_minimal.py
+++ b/marilib/examples/mari_cloud_minimal.py
@@ -28,7 +28,7 @@ def main():
             mari_cloud.send_frame(dst=node.address, payload=b"NORMAL_APP_DATA")
             print(",", end="", flush=True)
         statistics = [
-            (f"{node.address:016X}", node.stats.received_rssi_dbm()) for node in mari_cloud.nodes
+            (f"{node.address:016X}", node.stats_rssi_node_dbm()) for node in mari_cloud.nodes
         ]
         print(f"Network statistics: {statistics}")
         time.sleep(1)

--- a/marilib/examples/mari_edge_minimal.py
+++ b/marilib/examples/mari_edge_minimal.py
@@ -27,7 +27,7 @@ def main():
                 mari_edge.send_frame(dst=node.address, payload=b"NORMAL_APP_DATA")
                 print(",", end="", flush=True)
         statistics = [
-            (f"{node.address:016X}", node.stats.received_rssi_dbm()) for node in mari_edge.nodes
+            (f"{node.address:016X}", node.stats_rssi_node_dbm()) for node in mari_edge.nodes
         ]
         print(f"Stats: {statistics}")
         time.sleep(3)

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -32,15 +32,41 @@ class NextProto(IntEnum):
     Mirror of mr_next_proto_t in firmware/mari/models.h. Meaningful when
     PacketType is DATA; for BEACON / JOIN_* / KEEPALIVE the field is
     always MARI_INTERNAL.
+
+    Numeric layout — high nibble names a category, low nibble names an
+    item within that category. 16 x 16 = 256 slots total::
+
+        0x00         reserved (null catcher)
+        0x01..0x0F   mari link-layer internal (metrics, control, ...)
+        0x10..0x1F   swarm-application protocols (DotBot, SwarmIT, ...)
+        0x20..0x2F   standardized network protocols (IPv4, IPv6, ARP, ...)
+        0x30..0xEF   reserved for future categories
+        0xF0..0xFE   experimental / private use
+        0xFF         reserved
     """
 
-    RESERVED = 0  # catches uninitialized memory
-    MARI_INTERNAL = 1  # default; mari's own control + metrics
-    DOTBOT_APP = 2  # DotBot application protocol
-    SWARMIT_TESTBED = 3  # SwarmIT testbed protocol
-    IPV4 = 4  # IPv4 packet (RFC 791)
-    IPV6 = 5  # IPv6 packet (RFC 8200)
+    RESERVED = 0x00  # catches uninitialized memory
+    MARI_INTERNAL = 0x01  # default; mari's own control + metrics
+    DOTBOT_APP = 0x10  # DotBot application protocol
+    SWARMIT_TESTBED = 0x11  # SwarmIT testbed protocol
+    IPV4 = 0x21  # IPv4 packet (RFC 791)
+    IPV6 = 0x22  # IPv6 packet (RFC 8200)
     EXPERIMENTAL = 0xFE  # experimental / private use
+
+
+@dataclass
+class MariTxConfig:
+    """Per-frame send configuration. Mirror of mari_tx_config_t in
+    firmware/mari/models.h. Future fields likely to land here: priority,
+    retry policy, TTL in slotframes, request for link-layer security."""
+
+    next_proto: int = NextProto.MARI_INTERNAL
+
+
+# Default config for mari's own internal traffic (metrics, control). Other
+# consumers (DotBot apps, SwarmIT, IP stacks) define their own MariTxConfig
+# constants — pattern documented in NextProto's enum body.
+MARI_TX_INTERNAL = MariTxConfig(next_proto=NextProto.MARI_INTERNAL)
 
 
 @dataclass

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -34,13 +34,13 @@ class NextProto(IntEnum):
     always MARI_INTERNAL.
     """
 
-    RESERVED = 0           # catches uninitialized memory
-    MARI_INTERNAL = 1      # default; mari's own control + metrics
-    DOTBOT_APP = 2         # DotBot application protocol
-    SWARMIT_TESTBED = 3    # SwarmIT testbed protocol
-    IPV4 = 4               # IPv4 packet (RFC 791)
-    IPV6 = 5               # IPv6 packet (RFC 8200)
-    EXPERIMENTAL = 0xFE    # experimental / private use
+    RESERVED = 0  # catches uninitialized memory
+    MARI_INTERNAL = 1  # default; mari's own control + metrics
+    DOTBOT_APP = 2  # DotBot application protocol
+    SWARMIT_TESTBED = 3  # SwarmIT testbed protocol
+    IPV4 = 4  # IPv4 packet (RFC 791)
+    IPV6 = 5  # IPv6 packet (RFC 8200)
+    EXPERIMENTAL = 0xFE  # experimental / private use
 
 
 @dataclass

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -36,7 +36,8 @@ class NextProto(IntEnum):
     Numeric layout — high nibble names a category, low nibble names an
     item within that category. 16 x 16 = 256 slots total::
 
-        0x00         reserved (null catcher)
+        0x00         unknown / unspecified (null catcher, also default
+                     for null cfg)
         0x01..0x0F   mari link-layer internal (metrics, control, ...)
         0x10..0x1F   swarm-application protocols (DotBot, SwarmIT, ...)
         0x20..0x2F   standardized network protocols (IPv4, IPv6, ARP, ...)
@@ -45,8 +46,8 @@ class NextProto(IntEnum):
         0xFF         reserved
     """
 
-    RESERVED = 0x00  # catches uninitialized memory
-    MARI_INTERNAL = 0x01  # default; mari's own control + metrics
+    UNKNOWN = 0x00  # null cfg / uninitialized / sender didn't say
+    MARI_INTERNAL = 0x01  # mari's own control + metrics
     DOTBOT_APP = 0x10  # DotBot application protocol
     SWARMIT_TESTBED = 0x11  # SwarmIT testbed protocol
     IPV4 = 0x21  # IPv4 packet (RFC 791)

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 
 from marilib.protocol import Packet, PacketFieldMetadata, PacketType
 
-MARI_PROTOCOL_VERSION = 2
+MARI_PROTOCOL_VERSION = 3
 MARI_BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 MARI_NET_ID_DEFAULT = 0x0001
 
@@ -33,25 +33,24 @@ class NextProto(IntEnum):
     PacketType is DATA; for BEACON / JOIN_* / KEEPALIVE the field is
     always MARI_INTERNAL.
 
-    Numeric layout — high nibble names a category, low nibble names an
-    item within that category. 16 x 16 = 256 slots total::
+    Numeric layout — ranges grouped by who owns the protocol::
 
-        0x00         unknown / unspecified (null catcher, also default
-                     for null cfg)
-        0x01..0x0F   mari link-layer internal (metrics, control, ...)
-        0x10..0x1F   swarm-application protocols (DotBot, SwarmIT, ...)
-        0x20..0x2F   standardized network protocols (IPv4, IPv6, ARP, ...)
-        0x30..0xEF   reserved for future categories
-        0xF0..0xFE   experimental / private use
-        0xFF         reserved
+        0x00         RESERVED — null catcher; also default for null cfg
+        0x01..0x09   mari link-layer internal (metrics, control, ...)
+        0x0A..0x0F   unallocated (future mari)
+        0x10..0x39   swarm-application / custom protocols
+        0x3A..0x9F   unallocated (future categories)
+        0xA0..0xFD   standardized network protocols (IPv4, IPv6, ARP, ...)
+        0xFE         experimental / private use
+        0xFF         reserved (high sentinel)
     """
 
-    UNKNOWN = 0x00  # null cfg / uninitialized / sender didn't say
+    RESERVED = 0x00  # null catcher / null cfg default
     MARI_INTERNAL = 0x01  # mari's own control + metrics
-    DOTBOT_APP = 0x10  # DotBot application protocol
-    SWARMIT_TESTBED = 0x11  # SwarmIT testbed protocol
-    IPV4 = 0x21  # IPv4 packet (RFC 791)
-    IPV6 = 0x22  # IPv6 packet (RFC 8200)
+    SWARMIT_TESTBED = 0x10  # SwarmIT testbed protocol
+    DOTBOT_APP = 0x11  # DotBot application protocol
+    IPV4 = 0xA0  # IPv4 packet (RFC 791)
+    IPV6 = 0xA1  # IPv6 packet (RFC 8200)
     EXPERIMENTAL = 0xFE  # experimental / private use
 
 

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -190,26 +190,24 @@ class MetricsProbePayload(Packet):
         if probe_stats_start_epoch is None:
             # if no epoch is provided, just wait a bit
             return -1
-        else:
-            # if epoch is provided, subtract the epoch values from the current values
-            if probe_stats_start_epoch.asn == 0:
-                return 0
-            # if a packet was received at the gatweway, it should also be received at the edge (otherwise, it's a loss)
-            gw_rx_count = self.gw_rx_count - probe_stats_start_epoch.gw_rx_count
-            edge_rx_count = self.edge_rx_count - probe_stats_start_epoch.edge_rx_count
+        # if epoch is provided, subtract the epoch values from the current values
+        if probe_stats_start_epoch.asn == 0:
+            return 0
+        # if a packet was received at the gatweway, it should also be received at the edge (otherwise, it's a loss)
+        gw_rx_count = self.gw_rx_count - probe_stats_start_epoch.gw_rx_count
+        edge_rx_count = self.edge_rx_count - probe_stats_start_epoch.edge_rx_count
         return self.pdr_saturated(edge_rx_count, gw_rx_count)
 
     def pdr_downlink_uart(self, probe_stats_start_epoch=None) -> float:
         if probe_stats_start_epoch is None:
             # if no epoch is provided, just wait a bit
             return -1
-        else:
-            # if epoch is provided, subtract the epoch values from the current values
-            if probe_stats_start_epoch.asn == 0:
-                return 0
-            # if a packet was sent at the edge, it should also be sent at the gateway (otherwise, it's a loss)
-            gw_tx_count = self.gw_tx_count - probe_stats_start_epoch.gw_tx_count
-            edge_tx_count = self.edge_tx_count - probe_stats_start_epoch.edge_tx_count
+        # if epoch is provided, subtract the epoch values from the current values
+        if probe_stats_start_epoch.asn == 0:
+            return 0
+        # if a packet was sent at the edge, it should also be sent at the gateway (otherwise, it's a loss)
+        gw_tx_count = self.gw_tx_count - probe_stats_start_epoch.gw_tx_count
+        edge_tx_count = self.edge_tx_count - probe_stats_start_epoch.edge_tx_count
         return self.pdr_saturated(gw_tx_count, edge_tx_count)
 
     def rssi_at_node_dbm(self) -> int:
@@ -257,24 +255,6 @@ class MetricsResponsePayload(Packet):
 
 
 @dataclass
-class HeaderStats(Packet):
-    """Dataclass that holds MAC header stats."""
-
-    metadata: list[PacketFieldMetadata] = dataclasses.field(
-        default_factory=lambda: [
-            PacketFieldMetadata(name="rssi", disp="rssi", length=1),
-        ]
-    )
-    rssi: int = 0
-
-    @property
-    def rssi_dbm(self) -> int:
-        if self.rssi > 127:
-            return self.rssi - 255
-        return self.rssi
-
-
-@dataclass
 class Header(Packet):
     """Dataclass that holds MAC header fields."""
 
@@ -303,21 +283,16 @@ class Frame:
     """Data class that holds a payload packet."""
 
     header: Header = None
-    stats: HeaderStats = dataclasses.field(default_factory=HeaderStats)
     payload: bytes = b""
 
     def from_bytes(self, bytes_):
         self.header = Header().from_bytes(bytes_[0:20])
         if len(bytes_) > 20:
-            self.stats = HeaderStats().from_bytes(bytes_[20:21])
-            if len(bytes_) > 21:
-                self.payload = bytes_[21:]
+            self.payload = bytes_[20:]
         return self
 
     def to_bytes(self, byteorder="little") -> bytes:
-        header_bytes = self.header.to_bytes(byteorder)
-        stats_bytes = self.stats.to_bytes(byteorder)
-        return header_bytes + stats_bytes + self.payload
+        return self.header.to_bytes(byteorder) + self.payload
 
     @property
     def is_test_packet(self) -> bool:

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -26,6 +26,23 @@ class DefaultPayloadType(IntEnum):
         return bytes([self.value])
 
 
+class NextProto(IntEnum):
+    """Upper-layer protocol multiplex for the mari packet header.
+
+    Mirror of mr_next_proto_t in firmware/mari/models.h. Meaningful when
+    PacketType is DATA; for BEACON / JOIN_* / KEEPALIVE the field is
+    always MARI_INTERNAL.
+    """
+
+    RESERVED = 0           # catches uninitialized memory
+    MARI_INTERNAL = 1      # default; mari's own control + metrics
+    DOTBOT_APP = 2         # DotBot application protocol
+    SWARMIT_TESTBED = 3    # SwarmIT testbed protocol
+    IPV4 = 4               # IPv4 packet (RFC 791)
+    IPV6 = 5               # IPv6 packet (RFC 8200)
+    EXPERIMENTAL = 0xFE    # experimental / private use
+
+
 @dataclass
 class DefaultPayload(Packet):
     metadata: list[PacketFieldMetadata] = dataclasses.field(
@@ -265,6 +282,7 @@ class Header(Packet):
             PacketFieldMetadata(name="network_id", disp="net", length=2),
             PacketFieldMetadata(name="destination", disp="dst", length=8),
             PacketFieldMetadata(name="source", disp="src", length=8),
+            PacketFieldMetadata(name="next_proto", disp="proto", length=1),
         ]
     )
     version: int = MARI_PROTOCOL_VERSION
@@ -272,10 +290,20 @@ class Header(Packet):
     network_id: int = MARI_NET_ID_DEFAULT
     destination: int = MARI_BROADCAST_ADDRESS
     source: int = 0x0000000000000000
+    next_proto: int = NextProto.MARI_INTERNAL
 
     def __repr__(self):
         type_ = PacketType(self.type_).name
-        return f"Header(version={self.version}, type_={type_}, network_id=0x{self.network_id:04x}, destination=0x{self.destination:016x}, source=0x{self.source:016x})"
+        try:
+            next_proto_name = NextProto(self.next_proto).name
+        except ValueError:
+            next_proto_name = f"0x{self.next_proto:02x}"
+        return (
+            f"Header(version={self.version}, type_={type_}, "
+            f"network_id=0x{self.network_id:04x}, "
+            f"destination=0x{self.destination:016x}, "
+            f"source=0x{self.source:016x}, next_proto={next_proto_name})"
+        )
 
 
 @dataclass
@@ -286,9 +314,9 @@ class Frame:
     payload: bytes = b""
 
     def from_bytes(self, bytes_):
-        self.header = Header().from_bytes(bytes_[0:20])
-        if len(bytes_) > 20:
-            self.payload = bytes_[20:]
+        self.header = Header().from_bytes(bytes_[0:21])
+        if len(bytes_) > 21:
+            self.payload = bytes_[21:]
         return self
 
     def to_bytes(self, byteorder="little") -> bytes:

--- a/marilib/marilib/marilib_cloud.py
+++ b/marilib/marilib/marilib_cloud.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Callable
 
 from marilib.metrics import MetricsTester
-from marilib.mari_protocol import Frame, Header
+from marilib.mari_protocol import Frame, Header, NextProto
 from marilib.model import (
     EdgeEvent,
     GatewayInfo,
@@ -39,6 +39,8 @@ class MarilibCloud(MarilibBase):
     started_ts: datetime = field(default_factory=datetime.now)
     last_received_mqtt_data_ts: datetime = field(default_factory=datetime.now)
     main_file: str | None = None
+
+    _proto_handlers: dict[int, Callable[[Frame], None]] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         self.setup_params = {
@@ -91,16 +93,25 @@ class MarilibCloud(MarilibBase):
                 return node
         return None
 
-    def send_frame(self, dst: int, payload: bytes):
+    def send_frame(self, dst: int, payload: bytes, next_proto: int = NextProto.MARI_INTERNAL):
         """
         Sends a frame to a gateway via MQTT.
         Consists in publishing a message to the /mari/{network_id}/to_edge topic.
         """
-        mari_frame = Frame(Header(destination=dst), payload=payload)
+        mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         self.mqtt_interface.send_data_to_edge(
             EdgeEvent.to_bytes(EdgeEvent.NODE_DATA) + mari_frame.to_bytes()
         )
+
+    def register_proto_handler(self, proto: int, handler: Callable[[Frame], None]) -> None:
+        """Register a callback for incoming DATA frames carrying `proto`.
+
+        Symmetric with MarilibEdge.register_proto_handler. The handler is
+        invoked from the MQTT receive path before the generic cb_application.
+        Only one handler per NextProto value; subsequent calls overwrite.
+        """
+        self._proto_handlers[int(proto)] = handler
 
     def render_tui(self):
         if self.tui:
@@ -198,6 +209,13 @@ class MarilibCloud(MarilibBase):
                     payload = self.metrics_tester.handle_response_cloud(frame, gateway, node)
                     if payload:
                         frame.payload = payload.to_bytes()
+
+                handler = self._proto_handlers.get(frame.header.next_proto)
+                if handler is not None:
+                    try:
+                        handler(frame)
+                    except Exception as exc:  # pylint: disable=broad-except
+                        print(f"proto_handler({frame.header.next_proto}) raised: {exc}")
 
                 return True, EdgeEvent.NODE_DATA, frame
 

--- a/marilib/marilib/marilib_cloud.py
+++ b/marilib/marilib/marilib_cloud.py
@@ -3,8 +3,10 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
 
+from marilib.communication_adapter import MQTTAdapter
+from marilib.mari_protocol import MARI_TX_INTERNAL, Frame, Header, MariTxConfig
+from marilib.marilib import MarilibBase
 from marilib.metrics import MetricsTester
-from marilib.mari_protocol import Frame, Header, NextProto
 from marilib.model import (
     EdgeEvent,
     GatewayInfo,
@@ -12,8 +14,6 @@ from marilib.model import (
     MariNode,
     NodeInfoCloud,
 )
-from marilib.communication_adapter import MQTTAdapter
-from marilib.marilib import MarilibBase
 from marilib.tui_cloud import MarilibTUICloud
 
 LOAD_PACKET_PAYLOAD = b"L"
@@ -93,12 +93,15 @@ class MarilibCloud(MarilibBase):
                 return node
         return None
 
-    def send_frame(self, dst: int, payload: bytes, next_proto: int = NextProto.MARI_INTERNAL):
+    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig = MARI_TX_INTERNAL):
         """
         Sends a frame to a gateway via MQTT.
         Consists in publishing a message to the /mari/{network_id}/to_edge topic.
+
+        `cfg` is a MariTxConfig (defaults to mari-internal); use a
+        namespace-specific constant for app traffic.
         """
-        mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
+        mari_frame = Frame(Header(destination=dst, next_proto=cfg.next_proto), payload=payload)
 
         self.mqtt_interface.send_data_to_edge(
             EdgeEvent.to_bytes(EdgeEvent.NODE_DATA) + mari_frame.to_bytes()

--- a/marilib/marilib/marilib_cloud.py
+++ b/marilib/marilib/marilib_cloud.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Callable
 
 from marilib.communication_adapter import MQTTAdapter
-from marilib.mari_protocol import MARI_TX_INTERNAL, Frame, Header, MariTxConfig
+from marilib.mari_protocol import Frame, Header, MariTxConfig, NextProto
 from marilib.marilib import MarilibBase
 from marilib.metrics import MetricsTester
 from marilib.model import (
@@ -93,15 +93,17 @@ class MarilibCloud(MarilibBase):
                 return node
         return None
 
-    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig = MARI_TX_INTERNAL):
+    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig | None = None):
         """
         Sends a frame to a gateway via MQTT.
         Consists in publishing a message to the /mari/{network_id}/to_edge topic.
 
-        `cfg` is a MariTxConfig (defaults to mari-internal); use a
-        namespace-specific constant for app traffic.
+        `cfg` is a MariTxConfig; if None, the frame is labeled
+        NextProto.UNKNOWN. Callers that want their traffic labeled
+        should pass an explicit cfg.
         """
-        mari_frame = Frame(Header(destination=dst, next_proto=cfg.next_proto), payload=payload)
+        next_proto = cfg.next_proto if cfg else NextProto.UNKNOWN
+        mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         self.mqtt_interface.send_data_to_edge(
             EdgeEvent.to_bytes(EdgeEvent.NODE_DATA) + mari_frame.to_bytes()

--- a/marilib/marilib/marilib_cloud.py
+++ b/marilib/marilib/marilib_cloud.py
@@ -99,10 +99,10 @@ class MarilibCloud(MarilibBase):
         Consists in publishing a message to the /mari/{network_id}/to_edge topic.
 
         `cfg` is a MariTxConfig; if None, the frame is labeled
-        NextProto.UNKNOWN. Callers that want their traffic labeled
+        NextProto.RESERVED (0). Callers that want their traffic labeled
         should pass an explicit cfg.
         """
-        next_proto = cfg.next_proto if cfg else NextProto.UNKNOWN
+        next_proto = cfg.next_proto if cfg else NextProto.RESERVED
         mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         self.mqtt_interface.send_data_to_edge(

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -8,11 +8,12 @@ from rich import print
 from marilib.communication_adapter import MQTTAdapter, MQTTAdapterDummy, SerialAdapter
 from marilib.mari_protocol import (
     MARI_BROADCAST_ADDRESS,
+    MARI_TX_INTERNAL,
     DefaultPayload,
     DefaultPayloadType,
     Frame,
     Header,
-    NextProto,
+    MariTxConfig,
 )
 from marilib.marilib import MarilibBase
 from marilib.metrics import EDGE_TX_TS_WIRE_OFFSET, MetricsTester
@@ -91,15 +92,17 @@ class MarilibEdge(MarilibBase):
         with self.lock:
             return self.gateway.remove_node(address)
 
-    def send_frame(self, dst: int, payload: bytes, next_proto: int = NextProto.MARI_INTERNAL):
+    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig = MARI_TX_INTERNAL):
         """Send a frame to the gateway via serial.
 
-        `next_proto` identifies which upper-layer namespace owns the
-        payload bytes (DotBot app, SwarmIT testbed, IPv4, IPv6, …).
+        `cfg` is a MariTxConfig carrying the upper-layer protocol label
+        (next_proto) and any future per-frame settings. Defaults to
+        mari-internal — callers sending app traffic should pass their
+        namespace's own MariTxConfig constant.
         """
         assert self.serial_interface is not None
 
-        mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
+        mari_frame = Frame(Header(destination=dst, next_proto=cfg.next_proto), payload=payload)
 
         with self.lock:
             self.gateway.register_sent_frame(mari_frame)

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -59,9 +59,7 @@ class MarilibEdge(MarilibBase):
     # NextProto values not in the table are still delivered to the generic
     # cb_application — registration is an "opt in to typed dispatch" hook,
     # not a wholesale replacement of the event callback.
-    _proto_handlers: dict[int, Callable[[Frame], None]] = field(
-        default_factory=dict, repr=False
-    )
+    _proto_handlers: dict[int, Callable[[Frame], None]] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         self.setup_params = {
@@ -106,9 +104,7 @@ class MarilibEdge(MarilibBase):
         """
         assert self.serial_interface is not None
 
-        mari_frame = Frame(
-            Header(destination=dst, next_proto=next_proto), payload=payload
-        )
+        mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         with self.lock:
             self.gateway.register_sent_frame(mari_frame)
@@ -290,9 +286,7 @@ class MarilibEdge(MarilibBase):
                         # A misbehaving handler must not break the rx loop —
                         # surface the error and fall through to the generic
                         # callback.
-                        print(
-                            f"[red]proto_handler({frame.header.next_proto}) raised: {exc}[/]"
-                        )
+                        print(f"[red]proto_handler({frame.header.next_proto}) raised: {exc}[/]")
 
                 return True, event_type, frame
             except (ValueError, ProtocolPayloadParserException):

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -8,12 +8,12 @@ from rich import print
 from marilib.communication_adapter import MQTTAdapter, MQTTAdapterDummy, SerialAdapter
 from marilib.mari_protocol import (
     MARI_BROADCAST_ADDRESS,
-    MARI_TX_INTERNAL,
     DefaultPayload,
     DefaultPayloadType,
     Frame,
     Header,
     MariTxConfig,
+    NextProto,
 )
 from marilib.marilib import MarilibBase
 from marilib.metrics import EDGE_TX_TS_WIRE_OFFSET, MetricsTester
@@ -92,17 +92,19 @@ class MarilibEdge(MarilibBase):
         with self.lock:
             return self.gateway.remove_node(address)
 
-    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig = MARI_TX_INTERNAL):
+    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig | None = None):
         """Send a frame to the gateway via serial.
 
         `cfg` is a MariTxConfig carrying the upper-layer protocol label
-        (next_proto) and any future per-frame settings. Defaults to
-        mari-internal — callers sending app traffic should pass their
-        namespace's own MariTxConfig constant.
+        (next_proto) and any future per-frame settings. If None (or if
+        the cfg's next_proto is 0), the frame goes out as
+        NextProto.UNKNOWN — callers that want their traffic labeled must
+        pass an explicit cfg with next_proto set.
         """
         assert self.serial_interface is not None
 
-        mari_frame = Frame(Header(destination=dst, next_proto=cfg.next_proto), payload=payload)
+        next_proto = cfg.next_proto if cfg else NextProto.UNKNOWN
+        mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         with self.lock:
             self.gateway.register_sent_frame(mari_frame)

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -96,14 +96,13 @@ class MarilibEdge(MarilibBase):
         """Send a frame to the gateway via serial.
 
         `cfg` is a MariTxConfig carrying the upper-layer protocol label
-        (next_proto) and any future per-frame settings. If None (or if
-        the cfg's next_proto is 0), the frame goes out as
-        NextProto.UNKNOWN — callers that want their traffic labeled must
-        pass an explicit cfg with next_proto set.
+        (next_proto) and any future per-frame settings. If None, the
+        frame goes out as NextProto.RESERVED (0) — callers that want
+        their traffic labeled must pass an explicit cfg.
         """
         assert self.serial_interface is not None
 
-        next_proto = cfg.next_proto if cfg else NextProto.UNKNOWN
+        next_proto = cfg.next_proto if cfg else NextProto.RESERVED
         mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         with self.lock:

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -2,27 +2,29 @@ import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
+
 from rich import print
 
-from marilib.metrics import EDGE_TX_TS_WIRE_OFFSET, MetricsTester
+from marilib.communication_adapter import MQTTAdapter, MQTTAdapterDummy, SerialAdapter
 from marilib.mari_protocol import (
     MARI_BROADCAST_ADDRESS,
-    Frame,
-    Header,
     DefaultPayload,
     DefaultPayloadType,
+    Frame,
+    Header,
+    NextProto,
 )
+from marilib.marilib import MarilibBase
+from marilib.metrics import EDGE_TX_TS_WIRE_OFFSET, MetricsTester
 from marilib.model import (
+    SCHEDULES,
     EdgeEvent,
     GatewayInfo,
     MariGateway,
     MariNode,
     NodeInfoEdge,
-    SCHEDULES,
 )
 from marilib.protocol import ProtocolPayloadParserException
-from marilib.communication_adapter import MQTTAdapter, MQTTAdapterDummy, SerialAdapter
-from marilib.marilib import MarilibBase
 from marilib.tui_edge import MarilibTUIEdge
 
 
@@ -50,6 +52,16 @@ class MarilibEdge(MarilibBase):
     last_received_serial_data_ts: datetime = field(default_factory=datetime.now)
     last_received_mqtt_data_ts: datetime = field(default_factory=datetime.now)
     main_file: str | None = None
+
+    # Per-NextProto callback table for received DATA frames. Populated via
+    # register_proto_handler(). Each handler is called with the full Frame
+    # so it can read frame.header.source / .destination as well as payload.
+    # NextProto values not in the table are still delivered to the generic
+    # cb_application — registration is an "opt in to typed dispatch" hook,
+    # not a wholesale replacement of the event callback.
+    _proto_handlers: dict[int, Callable[[Frame], None]] = field(
+        default_factory=dict, repr=False
+    )
 
     def __post_init__(self):
         self.setup_params = {
@@ -84,11 +96,19 @@ class MarilibEdge(MarilibBase):
         with self.lock:
             return self.gateway.remove_node(address)
 
-    def send_frame(self, dst: int, payload: bytes):
-        """Sends a frame to the gateway via serial."""
+    def send_frame(self, dst: int, payload: bytes, next_proto: int = NextProto.MARI_INTERNAL):
+        """Sends a frame to the gateway via serial.
+
+        `next_proto` identifies which upper-layer namespace owns the
+        payload bytes (DotBot app, SwarmIT testbed, IPv4, IPv6, …).
+        Defaults to MARI_INTERNAL so existing call sites that haven't
+        migrated keep their previous behavior.
+        """
         assert self.serial_interface is not None
 
-        mari_frame = Frame(Header(destination=dst), payload=payload)
+        mari_frame = Frame(
+            Header(destination=dst, next_proto=next_proto), payload=payload
+        )
 
         with self.lock:
             self.gateway.register_sent_frame(mari_frame)
@@ -126,6 +146,22 @@ class MarilibEdge(MarilibBase):
             EdgeEvent.to_bytes(EdgeEvent.NODE_DATA) + mari_frame.to_bytes(),
             late_stamp_offset=EDGE_TX_TS_WIRE_OFFSET,
         )
+
+    def register_proto_handler(self, proto: int, handler: Callable[[Frame], None]) -> None:
+        """Register a callback for incoming DATA frames carrying `proto`.
+
+        Only one handler per NextProto value; subsequent calls overwrite.
+        The handler is invoked synchronously from the serial RX path on
+        the same thread that drives handle_serial_data, BEFORE the frame
+        is delivered to the generic `cb_application` event callback —
+        so registered handlers can mutate frame state if needed and the
+        generic callback still sees the result.
+
+        Use NextProto.{MARI_INTERNAL, DOTBOT_APP, SWARMIT_TESTBED, IPV4,
+        IPV6, EXPERIMENTAL} for `proto`. Integers outside the enum are
+        accepted to leave room for private allocations.
+        """
+        self._proto_handlers[int(proto)] = handler
 
     def render_tui(self):
         if self.tui:
@@ -208,20 +244,19 @@ class MarilibEdge(MarilibBase):
             self.add_node(node_info.address)
             return True, event_type, node_info
 
-        elif event_type == EdgeEvent.NODE_LEFT:
+        if event_type == EdgeEvent.NODE_LEFT:
             node_info = NodeInfoEdge().from_bytes(data[1:])
             if self.remove_node(node_info.address):
                 return True, event_type, node_info
-            else:
-                return False, event_type, node_info
+            return False, event_type, node_info
 
-        elif event_type == EdgeEvent.NODE_KEEP_ALIVE:
+        if event_type == EdgeEvent.NODE_KEEP_ALIVE:
             node_info = NodeInfoEdge().from_bytes(data[1:])
             with self.lock:
                 self.gateway.update_node_liveness(node_info.address)
             return True, event_type, node_info
 
-        elif event_type == EdgeEvent.GATEWAY_INFO:
+        if event_type == EdgeEvent.GATEWAY_INFO:
             try:
                 with self.lock:
                     self.gateway.set_info(GatewayInfo().from_bytes(data[1:]))
@@ -241,6 +276,23 @@ class MarilibEdge(MarilibBase):
                         payload = self.metrics_tester.handle_response_edge(frame, rx_ts_us)
                         if payload:
                             frame.payload = payload.to_bytes()
+
+                # Dispatch to a registered NextProto handler if one is
+                # installed for this frame's next_proto. Fires after the
+                # mari-internal preprocessing above so handlers see the
+                # final frame.payload; before the return, so the generic
+                # cb_application is still reached afterwards.
+                handler = self._proto_handlers.get(frame.header.next_proto)
+                if handler is not None:
+                    try:
+                        handler(frame)
+                    except Exception as exc:  # pylint: disable=broad-except
+                        # A misbehaving handler must not break the rx loop —
+                        # surface the error and fall through to the generic
+                        # callback.
+                        print(
+                            f"[red]proto_handler({frame.header.next_proto}) raised: {exc}[/]"
+                        )
 
                 return True, event_type, frame
             except (ValueError, ProtocolPayloadParserException):

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -53,12 +53,9 @@ class MarilibEdge(MarilibBase):
     last_received_mqtt_data_ts: datetime = field(default_factory=datetime.now)
     main_file: str | None = None
 
-    # Per-NextProto callback table for received DATA frames. Populated via
-    # register_proto_handler(). Each handler is called with the full Frame
-    # so it can read frame.header.source / .destination as well as payload.
-    # NextProto values not in the table are still delivered to the generic
-    # cb_application — registration is an "opt in to typed dispatch" hook,
-    # not a wholesale replacement of the event callback.
+    # Per-NextProto receive handlers, populated by register_proto_handler.
+    # Frames with a matching next_proto are delivered here before the
+    # generic cb_application; unmatched frames go to cb_application only.
     _proto_handlers: dict[int, Callable[[Frame], None]] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
@@ -95,12 +92,10 @@ class MarilibEdge(MarilibBase):
             return self.gateway.remove_node(address)
 
     def send_frame(self, dst: int, payload: bytes, next_proto: int = NextProto.MARI_INTERNAL):
-        """Sends a frame to the gateway via serial.
+        """Send a frame to the gateway via serial.
 
         `next_proto` identifies which upper-layer namespace owns the
         payload bytes (DotBot app, SwarmIT testbed, IPv4, IPv6, …).
-        Defaults to MARI_INTERNAL so existing call sites that haven't
-        migrated keep their previous behavior.
         """
         assert self.serial_interface is not None
 
@@ -273,19 +268,11 @@ class MarilibEdge(MarilibBase):
                         if payload:
                             frame.payload = payload.to_bytes()
 
-                # Dispatch to a registered NextProto handler if one is
-                # installed for this frame's next_proto. Fires after the
-                # mari-internal preprocessing above so handlers see the
-                # final frame.payload; before the return, so the generic
-                # cb_application is still reached afterwards.
                 handler = self._proto_handlers.get(frame.header.next_proto)
                 if handler is not None:
                     try:
                         handler(frame)
                     except Exception as exc:  # pylint: disable=broad-except
-                        # A misbehaving handler must not break the rx loop —
-                        # surface the error and fall through to the generic
-                        # callback.
                         print(f"[red]proto_handler({frame.header.next_proto}) raised: {exc}[/]")
 
                 return True, event_type, frame

--- a/marilib/marilib/metrics.py
+++ b/marilib/marilib/metrics.py
@@ -3,14 +3,14 @@ import time
 from typing import TYPE_CHECKING
 
 from rich import print
+
 from marilib.mari_protocol import (
     DefaultPayloadType,
     Frame,
     Header,
-    HeaderStats,
     MetricsProbePayload,
 )
-from marilib.model import MariGateway, MariNode, MARI_PROBE_STATS_MAX_LEN
+from marilib.model import MARI_PROBE_STATS_MAX_LEN, MariGateway, MariNode
 
 if TYPE_CHECKING:
     from marilib.marilib_edge import MarilibEdge
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
 #   [Header bytes]              (sum of Header().metadata field lengths,
 #                                today 20: version + type_ + network_id
 #                                + dst + src)
-#   [HeaderStats bytes]         (sum of HeaderStats().metadata field
-#                                lengths, today 1: rssi)
 #   [MetricsProbePayload bytes] (the fields preceding edge_tx_ts_us in
 #                                MetricsProbePayload().metadata: type,
 #                                cloud_tx_ts_us, cloud_rx_ts_us,
@@ -39,7 +37,6 @@ if TYPE_CHECKING:
 EDGE_TX_TS_WIRE_OFFSET = (
     1
     + sum(f.length for f in Header().metadata)
-    + sum(f.length for f in HeaderStats().metadata)
     + sum(
         f.length
         for f in MetricsProbePayload().metadata

--- a/marilib/marilib/metrics.py
+++ b/marilib/marilib/metrics.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 #   [1 byte EdgeEvent prefix]   (prepended by send_probe;
 #                                EdgeEvent.NODE_DATA in EdgeEvent.to_bytes)
 #   [Header bytes]              (sum of Header().metadata field lengths,
-#                                today 20: version + type_ + network_id
-#                                + dst + src)
+#                                today 21: version + type_ + network_id
+#                                + dst + src + next_proto)
 #   [MetricsProbePayload bytes] (the fields preceding edge_tx_ts_us in
 #                                MetricsProbePayload().metadata: type,
 #                                cloud_tx_ts_us, cloud_rx_ts_us,

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -232,13 +232,6 @@ class FrameStats:
         r = self.received_count(window_secs, include_test_packets=True)
         return min(r / s, 1.0)
 
-    def received_rssi_dbm(self, window_secs: int = 0) -> float:
-        """Latest RSSI (dBm) measured at this node, from the most recent
-        MetricsProbePayload. `window_secs` is accepted but unused."""
-        del window_secs
-        latest = self.received_rssi_dbm_probe_node()
-        return float(latest) if latest is not None else 0.0
-
 
 @dataclass
 class MariNode:

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -233,11 +233,8 @@ class FrameStats:
         return min(r / s, 1.0)
 
     def received_rssi_dbm(self, window_secs: int = 0) -> float:
-        """Latest RSSI (dBm) measured at this node, sourced from the most
-        recent MetricsProbePayload. The `window_secs` parameter is kept
-        for API stability but ignored — historical per-frame RSSI is no
-        longer carried in the wire header (the byte was removed; RSSI
-        now travels only in periodic metrics probes)."""
+        """Latest RSSI (dBm) measured at this node, from the most recent
+        MetricsProbePayload. `window_secs` is accepted but unused."""
         del window_secs
         latest = self.received_rssi_dbm_probe_node()
         return float(latest) if latest is not None else 0.0

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -3,6 +3,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import IntEnum
+
 import rich
 
 from marilib.mari_protocol import Frame, MetricsProbePayload
@@ -197,14 +198,13 @@ class FrameStats:
         now = datetime.now()
         if include_test_packets:
             return len([e for e in self.sent if now - e.ts < timedelta(seconds=window_secs)])
-        else:
-            return len(
-                [
-                    e
-                    for e in self.sent
-                    if now - e.ts < timedelta(seconds=window_secs) and not e.frame.is_test_packet
-                ]
-            )
+        return len(
+            [
+                e
+                for e in self.sent
+                if now - e.ts < timedelta(seconds=window_secs) and not e.frame.is_test_packet
+            ]
+        )
 
     def received_count(self, window_secs: int = 0, include_test_packets: bool = True) -> int:
         if window_secs == 0:
@@ -233,18 +233,14 @@ class FrameStats:
         return min(r / s, 1.0)
 
     def received_rssi_dbm(self, window_secs: int = 0) -> float:
-        if not self.received:
-            return 0
-
-        if window_secs == 0:
-            return int(self.received[-1].frame.stats.rssi_dbm) if self.received else 0
-        n = datetime.now()
-        d = [
-            e.frame.stats.rssi_dbm
-            for e in self.received
-            if (n - e.ts < timedelta(seconds=window_secs))
-        ]
-        return int(sum(d) / len(d) if d else 0)
+        """Latest RSSI (dBm) measured at this node, sourced from the most
+        recent MetricsProbePayload. The `window_secs` parameter is kept
+        for API stability but ignored — historical per-frame RSSI is no
+        longer carried in the wire header (the byte was removed; RSSI
+        now travels only in periodic metrics probes)."""
+        del window_secs
+        latest = self.received_rssi_dbm_probe_node()
+        return float(latest) if latest is not None else 0.0
 
 
 @dataclass
@@ -458,15 +454,15 @@ class GatewayInfo(Packet):
         is_used = bool(int(is_used))
         if cell == "B":
             return rich.text.Text("B", style=f"bold white on {'red' if is_used else 'indian_red'}")
-        elif cell == "S":
+        if cell == "S":
             return rich.text.Text(
                 "S", style=f"bold white on {'purple' if is_used else 'medium_purple2'}"
             )
-        elif cell == "D":
+        if cell == "D":
             return rich.text.Text(
                 "D", style=f"bold white on {'green' if is_used else 'sea_green3'}"
             )
-        elif cell == "U":
+        if cell == "U":
             return rich.text.Text(
                 "U", style=f"bold white on {'yellow' if is_used else 'light_yellow3'}"
             )

--- a/marilib/tests/test_protocol.py
+++ b/marilib/tests/test_protocol.py
@@ -1,13 +1,13 @@
-from marilib.mari_protocol import Frame, Header
+from marilib.mari_protocol import Frame, Header, NextProto
 
 
 def test_header_size():
-    assert Header().size == 20
+    assert Header().size == 21
 
 
 def test_header_from_bytes():
     header = Header().from_bytes(
-        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef0399f0f0f0f0f0")[0:20]
+        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")[0:21]
     )
     assert header.version == 2
     assert header.type_ == 16
@@ -16,11 +16,12 @@ def test_header_from_bytes():
         bytes.fromhex("59291ba8fdcecef5"), byteorder="little"
     )
     assert header.source == int.from_bytes(bytes.fromhex("31eb7f2526ef0399"), byteorder="little")
+    assert header.next_proto == NextProto.MARI_INTERNAL
 
 
 def test_frame_from_bytes():
     frame = Frame().from_bytes(
-        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef0399f0f0f0f0f0")
+        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")
     )
     assert frame.header.version == 2
     assert frame.header.type_ == 16
@@ -31,4 +32,5 @@ def test_frame_from_bytes():
     assert frame.header.source == int.from_bytes(
         bytes.fromhex("31eb7f2526ef0399"), byteorder="little"
     )
+    assert frame.header.next_proto == NextProto.MARI_INTERNAL
     assert frame.payload == bytes.fromhex("f0f0f0f0f0")

--- a/marilib/tests/test_protocol.py
+++ b/marilib/tests/test_protocol.py
@@ -29,9 +29,9 @@ def test_header_repr_handles_unknown_next_proto():
 
 def test_header_from_bytes():
     header = Header().from_bytes(
-        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")[0:21]
+        bytes.fromhex("0310170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")[0:21]
     )
-    assert header.version == 2
+    assert header.version == 3
     assert header.type_ == 16
     assert header.network_id == 23
     assert header.destination == int.from_bytes(
@@ -43,9 +43,9 @@ def test_header_from_bytes():
 
 def test_frame_from_bytes():
     frame = Frame().from_bytes(
-        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")
+        bytes.fromhex("0310170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")
     )
-    assert frame.header.version == 2
+    assert frame.header.version == 3
     assert frame.header.type_ == 16
     assert frame.header.network_id == 23
     assert frame.header.destination == int.from_bytes(

--- a/marilib/tests/test_protocol.py
+++ b/marilib/tests/test_protocol.py
@@ -5,6 +5,28 @@ def test_header_size():
     assert Header().size == 21
 
 
+def test_header_roundtrip_next_proto_dotbot():
+    """Sender sets next_proto=DOTBOT_APP, receiver reads it back unchanged."""
+    h = Header(destination=0x1234, next_proto=NextProto.DOTBOT_APP)
+    parsed = Header().from_bytes(h.to_bytes())
+    assert parsed.next_proto == NextProto.DOTBOT_APP
+    assert parsed.destination == 0x1234
+
+
+def test_header_roundtrip_next_proto_ipv6():
+    """IPV6 round-trip — confirms the enum carries non-mari values."""
+    h = Header(next_proto=NextProto.IPV6)
+    parsed = Header().from_bytes(h.to_bytes())
+    assert parsed.next_proto == NextProto.IPV6
+
+
+def test_header_repr_handles_unknown_next_proto():
+    """An out-of-enum next_proto value renders as hex without raising."""
+    h = Header(next_proto=0x42)
+    s = repr(h)
+    assert "next_proto=0x42" in s
+
+
 def test_header_from_bytes():
     header = Header().from_bytes(
         bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef039901f0f0f0f0f0")[0:21]

--- a/marilib/tests/test_protocol.py
+++ b/marilib/tests/test_protocol.py
@@ -20,7 +20,7 @@ def test_header_from_bytes():
 
 def test_frame_from_bytes():
     frame = Frame().from_bytes(
-        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef0399dcf0f0f0f0f0")
+        bytes.fromhex("0210170059291ba8fdcecef531eb7f2526ef0399f0f0f0f0f0")
     )
     assert frame.header.version == 2
     assert frame.header.type_ == 16
@@ -31,5 +31,4 @@ def test_frame_from_bytes():
     assert frame.header.source == int.from_bytes(
         bytes.fromhex("31eb7f2526ef0399"), byteorder="little"
     )
-    assert frame.stats.rssi_dbm == -35
     assert frame.payload == bytes.fromhex("f0f0f0f0f0")


### PR DESCRIPTION
## Summary

Repurposes the last byte of the Mari packet header from a receiver-overwritten RSSI annotation to a sender-controlled `next_proto` field — the EtherType / PPP-Protocol / IPv6-Next-Header analogue. Mari becomes a generic link layer that can carry any upper-layer protocol; consumers register typed receive handlers and label outgoing traffic, instead of every receiver having to know every other consumer's payload IDs.

Companion downstream PR: [swarmit#139](https://github.com/DotBots/swarmit/pull/139) bumps swarmit's mari submodule to this branch and labels all swarmit traffic.

## Design notes

- `next_proto` is meaningful when frame type is `DATA`. For `BEACON`/`JOIN_*`/`KEEPALIVE` the field is always `MARI_INTERNAL` by definition.
- Header size stays 21 bytes — the rssi byte slot is reused for next_proto, no net growth.
- Default value `1` (not `0`): uninitialized memory deserializes as `RESERVED`, which won't silently collide with any real namespace and is easy to spot in a debugger.
- The firmware sender API (`mari_node_tx_payload`, `mr_build_packet_data`, `_set_header`) takes `mr_next_proto_t` as a required argument — hard signature break. We're on develop with no compat guarantees and this is the right moment for the wire-format break; every consumer must label its traffic correctly for the dispatch to be meaningful.
- Host-side per-frame RSSI is sourced from `MetricsProbePayload.rssi_at_{node,gw}` (already populated by both ends of the link and shipped in periodic metrics probes).
- IP-over-Mari is now a textbook drop-in: run an IPv6 stack, register a handler for `NextProto.IPV6`, send with `next_proto=NextProto.IPV6`. Mari core stays oblivious to upper-layer semantics — same way Ethernet carries IPv4/IPv6 via EtherType.

## Test plan

- [x] `hatch test` (marilib): 12/12 green.
- [x] CI: firmware build + 6× Python matrix all green.
- [x] Hardware: flash a gateway + node, verify normal join, OTA, and that swarmit#139 talks correctly to the updated mari (no host hardware at draft time).
- [ ] Once merged: swarmit#139's `.gitmodules` URL hunk can revert to point at upstream develop.