### PR TITLE
mari: pass next_proto as keyword arg, add UNKNOWN (0xFF) sentinel

### DIFF
--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -58,7 +58,7 @@ typedef enum {
 // definition.
 //
 typedef enum {
-    MARI_NEXT_PROTO_RESERVED = 0x00,  // null catcher / null cfg default
+    MARI_NEXT_PROTO_RESERVED = 0x00,  // null catcher (zeroed / uninitialized memory)
 
     MARI_NEXT_PROTO_MARI_INTERNAL = 0x01,  // mari's own control + metrics
     // 0x02..0x09 reserved for mari extensions
@@ -72,7 +72,7 @@ typedef enum {
     // 0xA2..0xFD reserved for standardized network protocols
 
     MARI_NEXT_PROTO_EXPERIMENTAL = 0xFE,  // experimental / private use
-    // 0xFF reserved (high sentinel)
+    MARI_NEXT_PROTO_UNKNOWN      = 0xFF,  // unclassified upper-layer protocol; default when next_proto unset
 } mr_next_proto_t;
 
 // Per-frame send configuration. Passed by pointer to the sender API so

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -81,16 +81,16 @@ static size_t _set_header(uint8_t                *buffer,
                           const mari_tx_config_t *cfg) {
     uint64_t src = mr_device_id();
 
-    // Null cfg → MARI_NEXT_PROTO_RESERVED (0). Same outcome as cfg with
-    // next_proto explicitly 0. Senders that want their traffic labeled
-    // must pass a non-null cfg with next_proto set.
+    // Null cfg → MARI_NEXT_PROTO_UNKNOWN (0xFF): the sender didn't classify
+    // the payload. A cfg with next_proto explicitly 0 stays RESERVED (0).
+    // Namespace owners pass a cfg with next_proto set.
     mr_packet_header_t header = {
         .version    = MARI_PROTOCOL_VERSION,
         .type       = packet_type,
         .network_id = mr_assoc_get_network_id(),
         .dst        = dst,
         .src        = src,
-        .next_proto = cfg ? cfg->next_proto : MARI_NEXT_PROTO_RESERVED,
+        .next_proto = cfg ? cfg->next_proto : MARI_NEXT_PROTO_UNKNOWN,
     };
     memcpy(buffer, &header, sizeof(mr_packet_header_t));
     return sizeof(mr_packet_header_t);

--- a/marilib/marilib/__init__.py
+++ b/marilib/marilib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.0rc1"
+__version__ = "0.9.0rc2"
 
 
 # declare these just to avoid circular imports

--- a/marilib/marilib/mari_protocol.py
+++ b/marilib/marilib/mari_protocol.py
@@ -35,38 +35,24 @@ class NextProto(IntEnum):
 
     Numeric layout — ranges grouped by who owns the protocol::
 
-        0x00         RESERVED — null catcher; also default for null cfg
+        0x00         RESERVED — null catcher (zeroed / uninitialized memory)
         0x01..0x09   mari link-layer internal (metrics, control, ...)
         0x0A..0x0F   unallocated (future mari)
         0x10..0x39   swarm-application / custom protocols
         0x3A..0x9F   unallocated (future categories)
         0xA0..0xFD   standardized network protocols (IPv4, IPv6, ARP, ...)
         0xFE         experimental / private use
-        0xFF         reserved (high sentinel)
+        0xFF         UNKNOWN — unclassified; default when next_proto unset
     """
 
-    RESERVED = 0x00  # null catcher / null cfg default
+    RESERVED = 0x00  # null catcher (zeroed / uninitialized memory)
     MARI_INTERNAL = 0x01  # mari's own control + metrics
     SWARMIT_TESTBED = 0x10  # SwarmIT testbed protocol
     DOTBOT_APP = 0x11  # DotBot application protocol
     IPV4 = 0xA0  # IPv4 packet (RFC 791)
     IPV6 = 0xA1  # IPv6 packet (RFC 8200)
     EXPERIMENTAL = 0xFE  # experimental / private use
-
-
-@dataclass
-class MariTxConfig:
-    """Per-frame send configuration. Mirror of mari_tx_config_t in
-    firmware/mari/models.h. Future fields likely to land here: priority,
-    retry policy, TTL in slotframes, request for link-layer security."""
-
-    next_proto: int = NextProto.MARI_INTERNAL
-
-
-# Default config for mari's own internal traffic (metrics, control). Other
-# consumers (DotBot apps, SwarmIT, IP stacks) define their own MariTxConfig
-# constants — pattern documented in NextProto's enum body.
-MARI_TX_INTERNAL = MariTxConfig(next_proto=NextProto.MARI_INTERNAL)
+    UNKNOWN = 0xFF  # unclassified; default when next_proto unset
 
 
 @dataclass

--- a/marilib/marilib/marilib.py
+++ b/marilib/marilib/marilib.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from marilib.mari_protocol import NextProto
 from marilib.model import MariNode
 
 
@@ -23,7 +24,7 @@ class MarilibBase(ABC):
         """Removes a node from the network."""
 
     @abstractmethod
-    def send_frame(self, dst: int, payload: bytes):
+    def send_frame(self, dst: int, payload: bytes, *, next_proto: int = NextProto.UNKNOWN):
         """Sends a frame to the network."""
 
     @abstractmethod

--- a/marilib/marilib/marilib_cloud.py
+++ b/marilib/marilib/marilib_cloud.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Callable
 
 from marilib.communication_adapter import MQTTAdapter
-from marilib.mari_protocol import Frame, Header, MariTxConfig, NextProto
+from marilib.mari_protocol import Frame, Header, NextProto
 from marilib.marilib import MarilibBase
 from marilib.metrics import MetricsTester
 from marilib.model import (
@@ -93,16 +93,14 @@ class MarilibCloud(MarilibBase):
                 return node
         return None
 
-    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig | None = None):
+    def send_frame(self, dst: int, payload: bytes, *, next_proto: int = NextProto.UNKNOWN):
         """
         Sends a frame to a gateway via MQTT.
         Consists in publishing a message to the /mari/{network_id}/to_edge topic.
 
-        `cfg` is a MariTxConfig; if None, the frame is labeled
-        NextProto.RESERVED (0). Callers that want their traffic labeled
-        should pass an explicit cfg.
+        `next_proto` labels the upper-layer protocol that owns the payload;
+        defaults to UNKNOWN (0xFF) so unlabeled traffic stays detectable.
         """
-        next_proto = cfg.next_proto if cfg else NextProto.RESERVED
         mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         self.mqtt_interface.send_data_to_edge(

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -12,7 +12,6 @@ from marilib.mari_protocol import (
     DefaultPayloadType,
     Frame,
     Header,
-    MariTxConfig,
     NextProto,
 )
 from marilib.marilib import MarilibBase
@@ -92,17 +91,15 @@ class MarilibEdge(MarilibBase):
         with self.lock:
             return self.gateway.remove_node(address)
 
-    def send_frame(self, dst: int, payload: bytes, cfg: MariTxConfig | None = None):
+    def send_frame(self, dst: int, payload: bytes, *, next_proto: int = NextProto.UNKNOWN):
         """Send a frame to the gateway via serial.
 
-        `cfg` is a MariTxConfig carrying the upper-layer protocol label
-        (next_proto) and any future per-frame settings. If None, the
-        frame goes out as NextProto.RESERVED (0) — callers that want
-        their traffic labeled must pass an explicit cfg.
+        `next_proto` labels the upper-layer protocol that owns the payload
+        (mr_next_proto_t). Defaults to UNKNOWN (0xFF) so unlabeled traffic
+        stays detectable; namespace owners pass their own value.
         """
         assert self.serial_interface is not None
 
-        next_proto = cfg.next_proto if cfg else NextProto.RESERVED
         mari_frame = Frame(Header(destination=dst, next_proto=next_proto), payload=payload)
 
         with self.lock:


### PR DESCRIPTION
marilib's `send_frame` took a `MariTxConfig` options object (mirroring the C
`mari_tx_config_t`). In Python that's unidiomatic ceremony — the reason a C API
passes a growable struct (can't add params without breaking call sites) doesn't
apply when keyword-only args with defaults give the same extensibility. So
`send_frame` takes `next_proto` directly now:

    mari.send_frame(dst, payload, next_proto=NextProto.DOTBOT_APP)

`MariTxConfig` / `MARI_TX_INTERNAL` are dropped on the Python side. The firmware
keeps `mari_tx_config_t` — the options-struct is the right idiom in C, and the
cross-language contract is the enum values, not the call convention.

Also adds `UNKNOWN` (0xFF) as the explicit "unclassified" value and makes it the
default when `next_proto` is unset (firmware null-cfg, and the Python kwarg
default). This splits two cases that previously both mapped to 0x00: `RESERVED`
(0x00) is now purely the zeroed/uninitialized-memory catcher, while `UNKNOWN`
(0xFF) means a sender that didn't classify its payload. The existing namespace
values are unchanged and the header layout is untouched (still a 1-byte field),
so this is not a wire-format change — only the default value emitted for
unlabeled frames moves 0x00 -> 0xFF.

Ships as `marilib-pkg 0.9.0rc2`. The swarmit/PyDotBot adapters move to the kwarg
form in their own PRs. Firmware compiles in CI and is hardware-validated.