### PR TITLE
firmware: add gateway-app makefile target

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,7 +4,7 @@ PACKAGES_DIR_OPT ?=
 SEGGER_DIR ?= /opt/segger
 BUILD_CONFIG ?= Debug
 
-.PHONY: all node gateway clean-gateway clean-node clean distclean docker
+.PHONY: all node gateway gateway-app gateway-net clean-gateway clean-gateway-app clean-gateway-net clean-node clean distclean docker
 
 all: node gateway
 
@@ -14,16 +14,29 @@ node:
 	@echo "\e[1mOutput binary: app/03app_node/Output/nrf52840dk/$(BUILD_CONFIG)/Exe/03app_node-nrf52840dk.bin\e[0m"
 	@echo "\e[1mDone\e[0m\n"
 
-gateway:
+gateway: gateway-app gateway-net
+
+gateway-app:
 	@echo "\e[1mBuilding $@ application\e[0m"
-	"$(SEGGER_DIR)/bin/emBuild" mari-gateway-net-nrf5340dk.emProject -project 03app_$@ -config $(BUILD_CONFIG) $(PACKAGES_DIR_OPT) -rebuild -verbose
+	"$(SEGGER_DIR)/bin/emBuild" mari-gateway-app-nrf5340dk.emProject -project 03app_gateway_app -config $(BUILD_CONFIG) $(PACKAGES_DIR_OPT) -rebuild -verbose
+	@echo "\e[1mOutput binary: app/03app_gateway_app/Output/nrf5340-app/$(BUILD_CONFIG)/Exe/03app_gateway_app-nrf5340-app.bin\e[0m"
+	@echo "\e[1mDone\e[0m\n"
+
+gateway-net:
+	@echo "\e[1mBuilding $@ application\e[0m"
+	"$(SEGGER_DIR)/bin/emBuild" mari-gateway-net-nrf5340dk.emProject -project 03app_gateway_net -config $(BUILD_CONFIG) $(PACKAGES_DIR_OPT) -rebuild -verbose
 	@echo "\e[1mOutput binary: app/03app_gateway_net/Output/nrf5340-net/$(BUILD_CONFIG)/Exe/03app_gateway_net-nrf5340-net.bin\e[0m"
 	@echo "\e[1mDone\e[0m\n"
 
 clean-node:
 	"$(SEGGER_DIR)/bin/emBuild" mari-node-nrf52840dk.emProject -config $(BUILD_CONFIG) -clean
 
-clean-gateway:
+clean-gateway: clean-gateway-app clean-gateway-net
+
+clean-gateway-app:
+	"$(SEGGER_DIR)/bin/emBuild" mari-gateway-app-nrf5340dk.emProject -config $(BUILD_CONFIG) -clean
+
+clean-gateway-net:
 	"$(SEGGER_DIR)/bin/emBuild" mari-gateway-net-nrf5340dk.emProject -config $(BUILD_CONFIG) -clean
 
 clean: clean-node clean-gateway


### PR DESCRIPTION
## Summary

The mari-gateway-app-nrf5340dk.emProject existed in the tree but had no Makefile target — only the gateway net-core build was wired up. Splits the existing `gateway` target into two granular ones (`gateway-app`, `gateway-net`) and keeps `gateway` as a convenience alias that builds both.

`clean-gateway` follows the same split.

This unblocks a swarmit-side CI step that wants to build both gateway cores via the mari submodule and ship the resulting hex files in tagged releases, so `dotbot-provision` can fetch them.

## Test plan

- [x] `make gateway-app` builds `mari-gateway-app-nrf5340dk.emProject` → `app/03app_gateway_app/Output/nrf5340-app/<config>/Exe/03app_gateway_app-nrf5340-app.{hex,bin,elf}`.
- [x] `make gateway-net` builds the existing target unchanged.
- [x] `make gateway` builds both.
- [x] Same via Docker: `DOCKER_TARGETS="gateway-app gateway-net" make docker` (no host hardware needed; CI runs this).