### PR TITLE
marilib/communication_adapter: MQTTAdapter username/password auth

### DIFF
--- a/marilib/marilib/__init__.py
+++ b/marilib/marilib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.0rc2"
+__version__ = "0.9.0rc3"
 
 
 # declare these just to avoid circular imports

--- a/marilib/marilib/communication_adapter.py
+++ b/marilib/marilib/communication_adapter.py
@@ -1,9 +1,9 @@
 import base64
 import time
-from urllib.parse import urlparse
-import paho.mqtt.client as mqtt
-
 from abc import ABC, abstractmethod
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
 from rich import print
 
 from marilib.serial_hdlc import (
@@ -12,7 +12,7 @@ from marilib.serial_hdlc import (
     HDLCState,
     hdlc_encode,
 )
-from marilib.serial_uart import SerialInterface, SERIAL_DEFAULT_BAUDRATE
+from marilib.serial_uart import SERIAL_DEFAULT_BAUDRATE, SerialInterface
 
 
 class CommunicationAdapterBase(ABC):
@@ -80,7 +80,15 @@ class SerialAdapter(CommunicationAdapterBase):
 class MQTTAdapter(CommunicationAdapterBase):
     """Class used to interface with MQTT."""
 
-    def __init__(self, host, port, is_edge: bool, use_tls: bool = False):
+    def __init__(
+        self,
+        host,
+        port,
+        is_edge: bool,
+        use_tls: bool = False,
+        username: str = None,
+        password: str = None,
+    ):
         self.host = host
         self.port = port
         self.is_edge = is_edge
@@ -88,20 +96,33 @@ class MQTTAdapter(CommunicationAdapterBase):
         self.client = None
         self.on_data_received = None
         self.use_tls = use_tls
+        self.username = username
+        self.password = password
         # optimize qos for throughput
         # 0 = no delivery guarantee, 1 = at least once, 2 = exactly once
         self.qos = 0
 
     @classmethod
-    def from_url(cls, url: str, is_edge: bool):
-        url = urlparse(url)
-        host, port = url.netloc.split(":")
-        if url.scheme == "mqtt":
-            return cls(host, int(port), is_edge, use_tls=False)
-        elif url.scheme == "mqtts":
-            return cls(host, int(port), is_edge, use_tls=True)
-        else:
+    def from_url(cls, url: str, is_edge: bool, username: str = None, password: str = None):
+        """Build an MQTTAdapter from a `mqtt(s)://[user:pass@]host:port` URL.
+
+        Credentials may be embedded in the URL (`mqtts://user:pass@host:port`)
+        or passed explicitly via `username` / `password` (explicit wins —
+        callers thread env-var credentials this way). Uses urlparse's
+        hostname/port/username/password so a userinfo prefix doesn't break
+        the host:port split.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme not in ("mqtt", "mqtts"):
             raise ValueError(f"Invalid MQTT URL: {url} (must start with mqtt:// or mqtts://)")
+        return cls(
+            parsed.hostname,
+            parsed.port,
+            is_edge,
+            use_tls=parsed.scheme == "mqtts",
+            username=username if username is not None else parsed.username,
+            password=password if password is not None else parsed.password,
+        )
 
     # ==== public methods ====
 
@@ -141,6 +162,8 @@ class MQTTAdapter(CommunicationAdapterBase):
             mqtt.CallbackAPIVersion.VERSION2,
             protocol=mqtt.MQTTProtocolVersion.MQTTv5,
         )
+        if self.username is not None:
+            self.client.username_pw_set(self.username, self.password)
         if self.use_tls:
             self.client.tls_set_context(context=None)
         self.client.on_log = self._on_log

--- a/marilib/marilib/communication_adapter.py
+++ b/marilib/marilib/communication_adapter.py
@@ -86,8 +86,8 @@ class MQTTAdapter(CommunicationAdapterBase):
         port,
         is_edge: bool,
         use_tls: bool = False,
-        username: str = None,
-        password: str = None,
+        username: str | None = None,
+        password: str | None = None,
     ):
         self.host = host
         self.port = port
@@ -103,23 +103,30 @@ class MQTTAdapter(CommunicationAdapterBase):
         self.qos = 0
 
     @classmethod
-    def from_url(cls, url: str, is_edge: bool, username: str = None, password: str = None):
-        """Build an MQTTAdapter from a `mqtt(s)://[user:pass@]host:port` URL.
+    def from_url(
+        cls,
+        url: str,
+        is_edge: bool,
+        username: str | None = None,
+        password: str | None = None,
+    ):
+        """Build an MQTTAdapter from a `mqtt(s)://[user:pass@]host[:port]` URL.
 
         Credentials may be embedded in the URL (`mqtts://user:pass@host:port`)
         or passed explicitly via `username` / `password` (explicit wins —
         callers thread env-var credentials this way). Uses urlparse's
         hostname/port/username/password so a userinfo prefix doesn't break
-        the host:port split.
+        the host:port split. A missing port defaults to 8883 (TLS) / 1883.
         """
         parsed = urlparse(url)
         if parsed.scheme not in ("mqtt", "mqtts"):
             raise ValueError(f"Invalid MQTT URL: {url} (must start with mqtt:// or mqtts://)")
+        use_tls = parsed.scheme == "mqtts"
         return cls(
             parsed.hostname,
-            parsed.port,
+            parsed.port or (8883 if use_tls else 1883),
             is_edge,
-            use_tls=parsed.scheme == "mqtts",
+            use_tls=use_tls,
             username=username if username is not None else parsed.username,
             password=password if password is not None else parsed.password,
         )

--- a/marilib/marilib/communication_adapter.py
+++ b/marilib/marilib/communication_adapter.py
@@ -77,6 +77,25 @@ class SerialAdapter(CommunicationAdapterBase):
             self.serial.write(encoded)
 
 
+def parse_mqtt_url(url: str):
+    """Parse a `mqtt(s)://[user:pass@]host[:port]` URL into its parts.
+
+    Returns `(host, port, use_tls, username, password)`. A missing port
+    defaults to 8883 (TLS) / 1883 (plain). `username`/`password` are
+    None when no userinfo is present. Raises ValueError on a bad scheme.
+
+    The single source of truth for the MQTT-URL → parts mapping, so the
+    `dotbot controller` / `dotbot swarm` CLIs (which can't import each
+    other) agree with `MQTTAdapter.from_url` on the parse + default port.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("mqtt", "mqtts"):
+        raise ValueError(f"Invalid MQTT URL: {url} (must start with mqtt:// or mqtts://)")
+    use_tls = parsed.scheme == "mqtts"
+    port = parsed.port or (8883 if use_tls else 1883)
+    return parsed.hostname, port, use_tls, parsed.username, parsed.password
+
+
 class MQTTAdapter(CommunicationAdapterBase):
     """Class used to interface with MQTT."""
 
@@ -114,21 +133,16 @@ class MQTTAdapter(CommunicationAdapterBase):
 
         Credentials may be embedded in the URL (`mqtts://user:pass@host:port`)
         or passed explicitly via `username` / `password` (explicit wins —
-        callers thread env-var credentials this way). Uses urlparse's
-        hostname/port/username/password so a userinfo prefix doesn't break
-        the host:port split. A missing port defaults to 8883 (TLS) / 1883.
+        callers thread env-var credentials this way).
         """
-        parsed = urlparse(url)
-        if parsed.scheme not in ("mqtt", "mqtts"):
-            raise ValueError(f"Invalid MQTT URL: {url} (must start with mqtt:// or mqtts://)")
-        use_tls = parsed.scheme == "mqtts"
+        host, port, use_tls, url_user, url_pass = parse_mqtt_url(url)
         return cls(
-            parsed.hostname,
-            parsed.port or (8883 if use_tls else 1883),
+            host,
+            port,
             is_edge,
             use_tls=use_tls,
-            username=username if username is not None else parsed.username,
-            password=password if password is not None else parsed.password,
+            username=username if username is not None else url_user,
+            password=password if password is not None else url_pass,
         )
 
     # ==== public methods ====
@@ -181,6 +195,8 @@ class MQTTAdapter(CommunicationAdapterBase):
         self.client.loop_start()
 
     def close(self):
+        if self.client is None:
+            return
         self.client.disconnect()
         self.client.loop_stop()
 

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -163,6 +163,14 @@ class MarilibEdge(MarilibBase):
         if self.tui:
             self.tui.close()
 
+    def close(self):
+        """Clean teardown: stop the metrics thread, close serial/mqtt/tui."""
+        if self.metrics_tester:
+            self.metrics_tester.stop()
+        self.serial_interface.close()
+        self.mqtt_interface.close()
+        self.close_tui()
+
     # ============================ MarilibEdge methods =========================
 
     @property

--- a/marilib/marilib/tests/test_communication_adapter.py
+++ b/marilib/marilib/tests/test_communication_adapter.py
@@ -1,6 +1,27 @@
 """Tests for MQTTAdapter URL parsing and credential handling."""
 
-from marilib.communication_adapter import MQTTAdapter
+from marilib.communication_adapter import MQTTAdapter, parse_mqtt_url
+
+
+def test_parse_mqtt_url_parts():
+    assert parse_mqtt_url("mqtts://argus:8883") == ("argus", 8883, True, None, None)
+    assert parse_mqtt_url("mqtt://localhost:1883") == (
+        "localhost",
+        1883,
+        False,
+        None,
+        None,
+    )
+
+
+def test_parse_mqtt_url_defaults_port():
+    assert parse_mqtt_url("mqtts://argus")[1] == 8883
+    assert parse_mqtt_url("mqtt://argus")[1] == 1883
+
+
+def test_parse_mqtt_url_credentials():
+    host, port, use_tls, user, pw = parse_mqtt_url("mqtts://alice:s3cret@argus:8883")
+    assert (host, port, use_tls, user, pw) == ("argus", 8883, True, "alice", "s3cret")
 
 
 def test_from_url_plain():

--- a/marilib/marilib/tests/test_communication_adapter.py
+++ b/marilib/marilib/tests/test_communication_adapter.py
@@ -1,0 +1,59 @@
+"""Tests for MQTTAdapter URL parsing and credential handling."""
+
+from marilib.communication_adapter import MQTTAdapter
+
+
+def test_from_url_plain():
+    a = MQTTAdapter.from_url("mqtt://localhost:1883", is_edge=True)
+    assert a.host == "localhost"
+    assert a.port == 1883
+    assert a.use_tls is False
+    assert a.username is None
+    assert a.password is None
+
+
+def test_from_url_tls():
+    a = MQTTAdapter.from_url("mqtts://argus.paris.inria.fr:8883", is_edge=False)
+    assert a.host == "argus.paris.inria.fr"
+    assert a.port == 8883
+    assert a.use_tls is True
+
+
+def test_from_url_with_embedded_credentials():
+    # A userinfo prefix must not break the host:port split.
+    a = MQTTAdapter.from_url("mqtts://alice:s3cret@argus:8883", is_edge=False)
+    assert a.host == "argus"
+    assert a.port == 8883
+    assert a.username == "alice"
+    assert a.password == "s3cret"
+
+
+def test_from_url_explicit_credentials_override_url():
+    a = MQTTAdapter.from_url(
+        "mqtts://urluser:urlpass@argus:8883",
+        is_edge=False,
+        username="envuser",
+        password="envpass",
+    )
+    # Explicit (env-fed) credentials win over URL-embedded ones.
+    assert a.username == "envuser"
+    assert a.password == "envpass"
+
+
+def test_from_url_explicit_credentials_without_url_userinfo():
+    a = MQTTAdapter.from_url("mqtts://argus:8883", is_edge=False, username="alice", password="pw")
+    assert a.username == "alice"
+    assert a.password == "pw"
+
+
+def test_from_url_rejects_bad_scheme():
+    import pytest
+
+    with pytest.raises(ValueError):
+        MQTTAdapter.from_url("http://nope:1", is_edge=True)
+
+
+def test_constructor_credentials_default_none():
+    a = MQTTAdapter("h", 1883, is_edge=True)
+    assert a.username is None
+    assert a.password is None

--- a/marilib/marilib/tests/test_communication_adapter.py
+++ b/marilib/marilib/tests/test_communication_adapter.py
@@ -19,6 +19,12 @@ def test_from_url_tls():
     assert a.use_tls is True
 
 
+def test_from_url_defaults_port_when_missing():
+    # No explicit port → 8883 for TLS, 1883 for plain.
+    assert MQTTAdapter.from_url("mqtts://argus", is_edge=False).port == 8883
+    assert MQTTAdapter.from_url("mqtt://argus", is_edge=True).port == 1883
+
+
 def test_from_url_with_embedded_credentials():
     # A userinfo prefix must not break the host:port split.
     a = MQTTAdapter.from_url("mqtts://alice:s3cret@argus:8883", is_edge=False)


### PR DESCRIPTION
Companion to the dotbot `--conn` redesign (DotBots/PyDotBot#258,
DotBots/swarmit#145). Those CLIs read `DOTBOT_MQTT_USER` /
`DOTBOT_MQTT_PASS` from the env and thread them to `MQTTAdapter`, but
the adapter had no way to use them — this adds it.

## Changes

- `MQTTAdapter.__init__` gains optional `username` / `password`; `init()`
  calls paho's `username_pw_set(...)` before `connect()`.
- `from_url()`:
  - parses credentials from a `mqtt(s)://user:pass@host:port` URL
    (via `urlparse`'s `username`/`password`/`hostname`/`port`);
  - accepts explicit `username`/`password` kwargs that **override** the
    URL ones (this is how the dotbot CLIs inject env-var credentials);
  - **fixes a latent bug**: the old `host, port = url.netloc.split(":")`
    raised on a userinfo prefix (`user:pass@…`) and on a missing port.
    `urlparse` attributes handle both.

Absent credentials → anonymous connect, exactly as before. No behaviour
change for existing callers (`mari-edge`, `mari-cloud`) that pass plain
`mqtt(s)://host:port`.

## Tests

New `marilib/tests/test_communication_adapter.py` (7): plain/TLS URLs,
URL-embedded creds, explicit-overrides-URL, explicit-without-URL, bad
scheme, default-None. `ruff check` + `ruff format` clean (line-length
100 per marilib config).

## Downstream

Once merged + released as a new `marilib-pkg` rc, the env-var auth in
PyDotBot#258 / swarmit#145 takes effect (they currently pin
`>= 0.9.0rc2` and forward credentials only when set, so they're
no-ops against the current release until the bump). In the editable
workspace venv it works now.