### PR TITLE
packet: only copy bloom filter into beacon when available

### DIFF
--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -55,8 +55,10 @@ size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, ui
         .remaining_capacity = remaining_capacity,
         .active_schedule_id = active_schedule_id,
     };
-    // add bloom filter
-    mr_bloom_gateway_copy(beacon.bloom_filter);
+    // add bloom filter, if available
+    if (mr_bloom_gateway_is_available()) {
+        mr_bloom_gateway_copy(beacon.bloom_filter);
+    }
     memcpy(buffer, &beacon, sizeof(mr_beacon_packet_header_t));
     return sizeof(mr_beacon_packet_header_t);
 }


### PR DESCRIPTION
## Problem

The gateway recomputes its bloom filter in the main loop, but beacons are
built in the radio slot ISR. When a beacon is built while a recompute is in
flight, it copies a half-rebuilt filter onto the air. A joined node that fails
the membership test on such a beacon concludes it has been evicted and leaves
with `MARI_PEER_LOST_BLOOM`.

Under a join storm this is frequent: the gateway sets the filter dirty and
recomputes after every join, so the recompute window is open much of the time,
and a single bad beacon can drop already-joined nodes. They rejoin, trigger
another recompute, and the network bounces instead of settling.

This regressed when the bloom became a mandatory beacon field in `8d20a54`,
which dropped the prior `mr_bloom_gateway_is_available()` guard around the copy.

## Change

Restore the guard: only copy the filter into the beacon when it is available,
so a beacon is never populated from a filter that is mid-recompute.

## Validation

On the testbed, the reason-6 (`MARI_PEER_LOST_BLOOM`) disconnects observed
during network formation no longer occur.

## Known limitation / follow-up

When the filter is unavailable the copy is skipped, which leaves the beacon's
`bloom_filter` field zeroed, and the node side has no empty-filter guard yet.
A node-side "treat an all-zero filter as no-info, skip the check" guard (or
gateway-side double-buffering) is a planned follow-up to close that remaining
window fully.