### PR TITLE
assoc: debounce bloom-based leave to tolerate stale/empty beacons

### DIFF
--- a/firmware/mari/association.c
+++ b/firmware/mari/association.c
@@ -69,6 +69,13 @@ mr_gpio_t led3 = { .port = 0, .pin = 31 };
 // and the gateway prioritizes join responses over all other downstream packets
 #define MARI_JOINING_STATE_TIMEOUT ((MARI_WHOLE_SLOT_DURATION * (2 - 1)) + (MARI_WHOLE_SLOT_DURATION / 2))  // apply a half-slot duration just so that the timeout happens before the slot boundary
 
+// Number of consecutive beacons that must omit this node from a non-empty bloom
+// filter before it leaves. A single omitting beacon can be stale (the gateway
+// has not recomputed its filter yet after a recent join), so leaving on one
+// would bounce freshly-joined nodes. The 3 beacon slots sit at the start of the
+// slotframe, so 3 misses span roughly one slotframe of consistent omission.
+#define MARI_BLOOM_MISS_THRESHOLD 3
+
 typedef struct {
     mr_assoc_state_t state;
     mr_event_cb_t    mari_event_callback;
@@ -82,6 +89,7 @@ typedef struct {
     uint32_t       join_response_timeout_ts;           ///< Time when the node will give up joining
     uint16_t       synced_gateway_remaining_capacity;  ///< Number of nodes that my gateway can still accept
     mr_event_tag_t is_pending_disconnect;              ///< Whether the node is pending a disconnect
+    uint8_t        bloom_miss_count;                   ///< Consecutive beacons whose non-empty bloom omitted this node
 } assoc_vars_t;
 
 //=========================== variables =======================================
@@ -186,6 +194,7 @@ void mr_assoc_node_handle_joined(uint64_t gateway_id) {
     mr_event_data_t event_data = { .data.gateway_info.gateway_id = gateway_id };
     assoc_vars.mari_event_callback(MARI_CONNECTED, event_data);
     assoc_vars.is_pending_disconnect = MARI_NONE;        // reset the pending disconnect flag
+    assoc_vars.bloom_miss_count      = 0;                // fresh join: do not carry over stale bloom misses
     mr_assoc_node_keep_gateway_alive(mr_mac_get_asn());  // initialize the gateway's keep-alive
     mr_assoc_node_reset_backoff();
 }
@@ -418,11 +427,18 @@ void mr_assoc_handle_beacon(uint8_t *packet, uint8_t length, uint8_t channel, ui
 
     bool from_my_gateway = beacon->src == mr_mac_get_synced_gateway();
     if (from_my_gateway && mr_assoc_is_joined()) {
-        bool still_joined = mr_bloom_node_contains(mr_device_id(), beacon->bloom_filter);
-        if (!still_joined) {
-            // node no longer joined to this gateway, so need to leave
-            assoc_vars.is_pending_disconnect = MARI_PEER_LOST_BLOOM;
-            return;
+        // An empty filter carries no membership info (gateway mid-recompute), so
+        // ignore it. A non-empty filter that omits us may be stale (gateway has
+        // not yet recomputed after a recent join) or a real eviction; only leave
+        // after MARI_BLOOM_MISS_THRESHOLD consecutive omitting beacons so a
+        // transient stale/empty beacon does not drop us.
+        if (!mr_bloom_is_empty(beacon->bloom_filter) && !mr_bloom_node_contains(mr_device_id(), beacon->bloom_filter)) {
+            if (++assoc_vars.bloom_miss_count >= MARI_BLOOM_MISS_THRESHOLD) {
+                assoc_vars.is_pending_disconnect = MARI_PEER_LOST_BLOOM;
+                return;
+            }
+        } else {
+            assoc_vars.bloom_miss_count = 0;
         }
 
         mr_assoc_node_keep_gateway_alive(mr_mac_get_asn());

--- a/firmware/mari/bloom.c
+++ b/firmware/mari/bloom.c
@@ -122,4 +122,16 @@ bool mr_bloom_node_contains(uint64_t node_id, const uint8_t *bloom) {
     return true;
 }
 
+// An all-zero filter carries no membership information: the gateway either has
+// not computed a filter yet or is shipping a placeholder while it recomputes.
+// Callers must not treat membership failure against such a filter as eviction.
+bool mr_bloom_is_empty(const uint8_t *bloom) {
+    for (size_t i = 0; i < MARI_BLOOM_M_BYTES; i++) {
+        if (bloom[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
 //=========================== private ==========================================

--- a/firmware/mari/bloom.h
+++ b/firmware/mari/bloom.h
@@ -40,5 +40,6 @@ void    mr_bloom_gateway_compute(void);
 void    mr_bloom_gateway_event_loop(void);
 
 bool mr_bloom_node_contains(uint64_t node_id, const uint8_t *bloom);
+bool mr_bloom_is_empty(const uint8_t *bloom);
 
 #endif  // __BLOOM_H


### PR DESCRIPTION
**Draft - pending hardware test on the testbed.**

## Problem

The gateway-side availability guard (#162) stopped beacons from carrying a
*partially* rebuilt filter, but it does not stop a joined node from leaving on
two remaining transient cases:

1. **Empty filter (mid-recompute).** While the gateway recomputes, the guard
   skips the copy and the beacon's `bloom_filter` ships all-zero. The node's
   membership test fails against all-zero and it leaves with
   `MARI_PEER_LOST_BLOOM`.
2. **Stale filter (recompute pending).** A node joins; the gateway marks the
   filter dirty but emits a beacon before it recomputes, so the beacon carries
   the previous *complete* filter that does not yet include the new node. The
   filter is non-empty, so it looks like a real eviction, and the freshly-joined
   node drops itself.

Both are transient: the next beacon, after the gateway recomputes, includes the
node again. Leaving on a single beacon turns these transients into a
join/leave bounce, which is most of the remaining slow network formation.

## Change

Make the node tolerant of transient beacons instead of acting on one:

- An **empty** filter carries no membership info, so it is ignored entirely.
- A **non-empty** filter that omits the node increments a miss counter; the node
  only leaves after `MARI_BLOOM_MISS_THRESHOLD` (3) **consecutive** omitting
  beacons. Any beacon that contains the node, or any empty beacon, resets the
  counter. The counter is also reset on join.

A genuine eviction (the gateway permanently drops the node) still triggers,
since its beacons consistently omit the node. With the 3 beacon slots at the
start of the slotframe, 3 consecutive misses span roughly one slotframe of
sustained omission.

## Validation

Builds clean. Needs a testbed run (40-node formation) to confirm the bounce is
gone and formation time drops; comparing against commit `4ea35db` is the
reference point.