### PR TITLE
bloom: send pass-all filter in beacons while recomputing

### DIFF
--- a/firmware/mari/bloom.c
+++ b/firmware/mari/bloom.c
@@ -69,6 +69,13 @@ bool mr_bloom_gateway_is_available(void) {
 }
 
 uint8_t mr_bloom_gateway_copy(uint8_t *output) {
+    if (!bloom_vars.is_available) {
+        // The filter is being (re)computed, so it is not safe to read. Emit a
+        // pass-all filter (all ones) instead: membership succeeds for every
+        // node, so a beacon sent mid-recompute never falsely evicts anyone.
+        memset(output, 0xFF, MARI_BLOOM_M_BYTES);
+        return MARI_BLOOM_M_BYTES;
+    }
     memcpy(output, bloom_vars.bloom, MARI_BLOOM_M_BYTES);
     return MARI_BLOOM_M_BYTES;
 }

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -55,10 +55,8 @@ size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, ui
         .remaining_capacity = remaining_capacity,
         .active_schedule_id = active_schedule_id,
     };
-    // add bloom filter, if available
-    if (mr_bloom_gateway_is_available()) {
-        mr_bloom_gateway_copy(beacon.bloom_filter);
-    }
+    // add bloom filter (copy emits a pass-all filter while it is being recomputed)
+    mr_bloom_gateway_copy(beacon.bloom_filter);
     memcpy(buffer, &beacon, sizeof(mr_beacon_packet_header_t));
     return sizeof(mr_beacon_packet_header_t);
 }


### PR DESCRIPTION
**Draft - pending a testbed run.**

## Problem

While the gateway recomputes its bloom filter, the filter is not safe to read.
The earlier guard (#162) handled this by skipping the copy, which left the
beacon's `bloom_filter` field zeroed - and an all-zero filter fails the
membership test for *every* node, so any joined node that received a beacon
mid-recompute was falsely evicted with `MARI_PEER_LOST_BLOOM`.

## Change

When the filter is mid-recompute, `mr_bloom_gateway_copy` now emits a
**pass-all** filter (all ones) instead. Membership succeeds for everyone, so a
beacon sent during recompute evicts nobody - the bloom check is simply a no-op
for that frame. The beacon builder calls the copy unconditionally again, since
the copy itself handles the not-ready case.

This is gateway-only and needs no node-side changes, so it supersedes the
node-side approach in #163 (empty-guard + miss debounce), which is now closed.

## Scope / caveat

This only removes *false* evictions during recompute. It does not address the
separate issue where the gateway legitimately times a node out (no uplink heard
for several slotframes) and the bloom then correctly reports the drop - that is
a synchronization/timing matter, tracked separately.

## Validation

Builds clean. Needs a testbed run to confirm the recompute-window false
evictions are gone.