### PR TITLE
mari: channel hopping for beacons and scanning

### DIFF
--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -402,9 +402,14 @@ static void start_or_continue_background_scan(void) {
     if (!mac_vars.is_bg_scanning) {
         set_slot_state(STATE_RX_DATA_LISTEN);
         mr_radio_disable();
-        // bg/handover scan listens on the fixed channel (not yet rotated across
-        // the advertising channels, unlike the cold scan above)
+#ifdef MARI_ENABLE_BEACON_HOPPING
+        // rotate the listen channel once per slotframe, so a full handover scan
+        // (which spans one slotframe) sweeps all advertising channels over
+        // successive slotframes and finds neighbours on any non-faded channel
+        mac_vars.current_scan_channel = MARI_N_BLE_REGULAR_CHANNELS + (mr_scheduler_get_slotframe_counter() % MARI_N_BLE_ADVERTISING_CHANNELS);
+#else
         mac_vars.current_scan_channel = MARI_FIXED_SCAN_CHANNEL;
+#endif
         mr_radio_set_channel(mac_vars.current_scan_channel);
         mr_radio_rx();
     }

--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -86,6 +86,8 @@ typedef struct {
     uint32_t scan_started_ts;       ///< Timestamp of the start of the scan
     uint32_t scan_expected_end_ts;  ///< Timestamp of the expected end of the scan
     uint32_t current_scan_item_ts;  ///< Timestamp of the current scan item
+    uint8_t  scan_channel_idx;      ///< Rotating index into the advertising channels for cold scan
+    uint8_t  current_scan_channel;  ///< Advertising channel currently being listened on (for beacon bookkeeping)
 
     bool is_bg_scanning;           ///< Whether the node is scanning for gateways in the background
     bool bg_scan_sleep_next_slot;  ///< Whether the next slot is a sleep slot
@@ -344,11 +346,15 @@ static void start_scan(void) {
 
     set_slot_state(STATE_RX_DATA_LISTEN);
     mr_radio_disable();
-#ifdef MARI_FIXED_SCAN_CHANNEL
-    mr_radio_set_channel(MARI_FIXED_SCAN_CHANNEL);  // not doing channel hopping for now
+#ifdef MARI_ENABLE_BEACON_HOPPING
+    // one advertising channel per scan round; a round that finds nothing retries
+    // on the next channel, so a faded channel is escaped within a round or two
+    mac_vars.current_scan_channel = MARI_N_BLE_REGULAR_CHANNELS + (mac_vars.scan_channel_idx % MARI_N_BLE_ADVERTISING_CHANNELS);
+    mac_vars.scan_channel_idx++;
 #else
-    puts("Channel hopping not implemented yet for scanning");
+    mac_vars.current_scan_channel = MARI_FIXED_SCAN_CHANNEL;
 #endif
+    mr_radio_set_channel(mac_vars.current_scan_channel);
     mr_radio_rx();
 }
 
@@ -396,11 +402,10 @@ static void start_or_continue_background_scan(void) {
     if (!mac_vars.is_bg_scanning) {
         set_slot_state(STATE_RX_DATA_LISTEN);
         mr_radio_disable();
-#ifdef MARI_FIXED_SCAN_CHANNEL
-        mr_radio_set_channel(MARI_FIXED_SCAN_CHANNEL);  // not doing channel hopping for now
-#else
-        puts("Channel hopping not implemented yet for scanning");
-#endif
+        // bg/handover scan listens on the fixed channel (not yet rotated across
+        // the advertising channels, unlike the cold scan above)
+        mac_vars.current_scan_channel = MARI_FIXED_SCAN_CHANNEL;
+        mr_radio_set_channel(mac_vars.current_scan_channel);
         mr_radio_rx();
     }
     mac_vars.is_bg_scanning = true;
@@ -784,7 +789,7 @@ static void activity_scan_end_frame(uint32_t end_frame_ts) {
     uint8_t packet_len;
     mr_radio_get_rx_packet(packet, &packet_len);
 
-    mr_assoc_handle_beacon(packet, packet_len, MARI_FIXED_SCAN_CHANNEL, mac_vars.current_scan_item_ts);
+    mr_assoc_handle_beacon(packet, packet_len, mac_vars.current_scan_channel, mac_vars.current_scan_item_ts);
 
     // if there is still enough time before end of scan, re-enable the radio
     bool still_time_for_rx_scan    = mac_vars.is_scanning && (end_frame_ts + MARI_BEACON_TOA_WITH_PADDING < mac_vars.scan_expected_end_ts);

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -30,6 +30,14 @@
 #define MARI_FIXED_SCAN_CHANNEL 37  // to hardcode the channel, use a valid value other than 0
 // #endif
 
+// Beacon/scan channel hopping. When defined, the gateway transmits each beacon
+// cell on its own BLE advertising channel (cell offset 0 -> 37, 1 -> 38,
+// 2 -> 39), synced nodes listen on the matching channel, and a scanning node
+// rotates its listen channel one per scan round - giving the beacon/join path
+// the frequency diversity the data slots already have. Comment out to keep all
+// beacons and scanning on MARI_FIXED_SCAN_CHANNEL (A/B comparison).
+#define MARI_ENABLE_BEACON_HOPPING
+
 #define MARI_N_CELLS_MAX 149
 
 #define MARI_ENABLE_BACKGROUND_SCAN 1

--- a/firmware/mari/scheduler.c
+++ b/firmware/mari/scheduler.c
@@ -94,6 +94,10 @@ uint32_t mr_scheduler_get_duration_us(void) {
     return MARI_WHOLE_SLOT_DURATION * _schedule_vars.active_schedule_ptr->n_cells;
 }
 
+uint32_t mr_scheduler_get_slotframe_counter(void) {
+    return _schedule_vars.slotframe_counter;
+}
+
 // ------------ node functions ------------
 
 // to be called at the NODE when processing a JOIN_RESPONSE

--- a/firmware/mari/scheduler.c
+++ b/firmware/mari/scheduler.c
@@ -24,14 +24,6 @@
 
 //=========================== defines ==========================================
 
-// Beacon channel hopping. When defined, the gateway transmits each beacon cell
-// on its own BLE advertising channel and synced nodes listen on the matching
-// channel, so the beacon path gets the frequency diversity the data slots
-// already have. Beacon cell channel_offset maps 0 -> 37, 1 -> 38, 2 -> 39.
-// Comment out to keep all beacons on MARI_FIXED_SCAN_CHANNEL (A/B comparison).
-// Unsynced scanning still uses MARI_FIXED_SCAN_CHANNEL.
-#define MARI_ENABLE_BEACON_HOPPING
-
 //=========================== variables ========================================
 
 typedef struct {

--- a/firmware/mari/scheduler.c
+++ b/firmware/mari/scheduler.c
@@ -24,6 +24,14 @@
 
 //=========================== defines ==========================================
 
+// Beacon channel hopping. When defined, the gateway transmits each beacon cell
+// on its own BLE advertising channel and synced nodes listen on the matching
+// channel, so the beacon path gets the frequency diversity the data slots
+// already have. Beacon cell channel_offset maps 0 -> 37, 1 -> 38, 2 -> 39.
+// Comment out to keep all beacons on MARI_FIXED_SCAN_CHANNEL (A/B comparison).
+// Unsynced scanning still uses MARI_FIXED_SCAN_CHANNEL.
+#define MARI_ENABLE_BEACON_HOPPING
+
 //=========================== variables ========================================
 
 typedef struct {
@@ -207,11 +215,11 @@ uint8_t mr_scheduler_get_channel(slot_type_t slot_type, uint64_t asn, uint8_t ch
     return MARI_FIXED_CHANNEL;
 #endif
     if (slot_type == SLOT_TYPE_BEACON) {
-#ifdef MARI_FIXED_SCAN_CHANNEL
-        return MARI_FIXED_SCAN_CHANNEL;
+#ifdef MARI_ENABLE_BEACON_HOPPING
+        // one advertising channel per beacon cell: offset 0 -> 37, 1 -> 38, 2 -> 39
+        return MARI_N_BLE_REGULAR_CHANNELS + (channel_offset % MARI_N_BLE_ADVERTISING_CHANNELS);
 #else
-        // special handling in case the cell is a beacon
-        return MARI_N_BLE_REGULAR_CHANNELS + (asn % MARI_N_BLE_ADVERTISING_CHANNELS);
+        return MARI_FIXED_SCAN_CHANNEL;
 #endif
     } else {
         // As per RFC 7554:

--- a/firmware/mari/scheduler.h
+++ b/firmware/mari/scheduler.h
@@ -52,6 +52,8 @@ bool mr_scheduler_set_schedule(uint8_t schedule_id);
 
 uint32_t mr_scheduler_get_duration_us(void);
 
+uint32_t mr_scheduler_get_slotframe_counter(void);
+
 int16_t mr_scheduler_gateway_assign_next_available_uplink_cell(uint64_t node_id, uint64_t asn);
 
 bool mr_scheduler_node_assign_myself_to_cell(uint16_t cell_index);


### PR DESCRIPTION
Nodes could drop and then get stuck rescanning for many seconds, only recovering
when the RF environment changed (someone moving nearby, etc). Root cause: data
slots already hop channels, but the entire beacon/join path was pinned to one
frequency (MARI_FIXED_SCAN_CHANNEL = 37 / 2402 MHz). A static multipath null at
that frequency at a node's location traps a rescanning node - it cannot hear a
single beacon until the environment shifts. No frequency diversity, no way out.

This gives the beacon/join path the same frequency diversity the data slots
already have, in three parts, all behind one build flag (MARI_ENABLE_BEACON_HOPPING
in models.h; with it off, behaviour is unchanged and everything stays on
MARI_FIXED_SCAN_CHANNEL, so it is an easy A/B on a logic analyzer):

- Beacon TX + synced RX: each of the 3 leading beacon cells uses its own
  advertising channel (cell offset 0 -> 37, 1 -> 38, 2 -> 39). Gateway and synced
  nodes both derive the channel from the cell, so they rendezvous with no extra
  coordination.
- Cold scan: rotates one advertising channel per scan round and syncs to the
  first gateway it hears; a round that finds nothing retries on the next channel,
  so a faded channel is escaped within a round or two. Reuses the existing
  scan-retry loop (no sweep-then-pick), and selecting per round keeps every
  reading inside mr_scan_select's freshness window.
- Background/handover scan: rotates the listen channel once per slotframe via
  slotframe_counter, so successive slotframes sweep all three channels and a
  neighbour is found on any non-faded channel within ~3 slotframes.

Known follow-up (cosmetic): the synced-RX beacon from a node's own gateway still
records its RSSI under the fixed channel rather than the real received channel.
That entry is excluded from handover selection and the hysteresis reads RSSI from
the received packet (not the scan list), so no decision changes.

Validated: node (nRF52840) and gateway (nRF5340) build clean via SES; testbed
validation underway.