### PR TITLE
mari: filter handover rssi on both sides, lower hysteresis to 12 dB

### DIFF
--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -660,7 +660,11 @@ static void fix_drift(uint32_t ts) {
 // --------------------- handover --------------------
 
 static bool select_gateway_for_handover(uint32_t now_ts, mr_channel_info_t *selected_gateway) {
-    if (!mr_scan_select(selected_gateway, mac_vars.scan_started_ts, now_ts)) {
+    // select over the full advertising-channel sweep (the bg scan listens on one
+    // channel per slotframe), so the decision averages a candidate across all
+    // channels instead of seeing only the last burst's single-channel sample
+    uint32_t sweep_duration_us = MARI_N_BLE_ADVERTISING_CHANNELS * mr_scheduler_get_duration_us();
+    if (!mr_scan_select(selected_gateway, now_ts - sweep_duration_us, now_ts)) {
         // no gateway found, do nothing
         return false;
     }

--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -100,6 +100,8 @@ typedef struct {
     uint64_t synced_gateway;     ///< ID of the gateway the node is synchronized with
     uint16_t synced_network_id;  ///< Network ID of the gateway the node is synchronized with
     uint32_t synced_ts;          ///< Timestamp of the last synchronization
+
+    int8_t synced_gateway_rssi_ewma;  ///< Smoothed rssi of packets received from the synced gateway; serving side of the handover hysteresis check
 } mac_vars_t;
 
 //=========================== variables ========================================
@@ -610,12 +612,18 @@ static void activity_ri4(uint32_t ts) {
         fix_drift(mac_vars.received_packet.start_ts);
     }
 
-    // store info about the received packet; rssi is used by the handover
-    // hysteresis check below
+    // store info about the received packet
     mac_vars.received_packet.channel = mac_vars.current_slot_info.channel;
     mac_vars.received_packet.rssi    = mr_radio_rssi();
     mac_vars.received_packet.end_ts  = ts;
     mac_vars.received_packet.asn     = mac_vars.asn;
+
+    if (mari_get_node_type() == MARI_NODE && header->src == mac_vars.synced_gateway) {
+        // smooth the serving gateway's rssi for the handover hysteresis check:
+        // a single sample can sit in a per-channel fade, and received_packet
+        // alone may hold a packet from another source (e.g. a foreign beacon)
+        mac_vars.synced_gateway_rssi_ewma += (int8_t)((mac_vars.received_packet.rssi - mac_vars.synced_gateway_rssi_ewma) >> MARI_HANDOVER_RSSI_EWMA_SHIFT);
+    }
 
     mr_handle_packet(mac_vars.received_packet.packet, mac_vars.received_packet.packet_len);
 
@@ -674,7 +682,7 @@ static bool select_gateway_for_handover(uint32_t now_ts, mr_channel_info_t *sele
         return false;
     }
 
-    if (selected_gateway->rssi < (mac_vars.received_packet.rssi + MARI_HANDOVER_RSSI_HYSTERESIS)) {
+    if (selected_gateway->rssi < (mac_vars.synced_gateway_rssi_ewma + MARI_HANDOVER_RSSI_HYSTERESIS)) {
         // the new gateway is not strong enough, ignore it
         return false;
     }
@@ -756,6 +764,9 @@ static bool sync_to_gateway(uint32_t now_ts, mr_channel_info_t *selected_gateway
     mac_vars.synced_gateway    = selected_gateway->beacon.src;
     mac_vars.synced_network_id = selected_gateway->beacon.network_id;
     mac_vars.synced_ts         = now_ts;
+    // seed the serving-side smoothing from the (cross-channel averaged) rssi
+    // that won the selection; refined on every packet received from the gateway
+    mac_vars.synced_gateway_rssi_ewma = selected_gateway->rssi;
 
     // the selected gateway may have been scanned a few slot_durations ago, so we need to account for that difference
     // NOTE: this assumes that the slot duration is the same for gateways and nodes

--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -668,6 +668,11 @@ static void fix_drift(uint32_t ts) {
 // --------------------- handover --------------------
 
 static bool select_gateway_for_handover(uint32_t now_ts, mr_channel_info_t *selected_gateway) {
+    if (now_ts - mac_vars.synced_ts < MARI_HANDOVER_MIN_INTERVAL) {
+        // just recently performed a synchronization, will not try again so soon
+        return false;
+    }
+
     // select over the full advertising-channel sweep (the bg scan listens on one
     // channel per slotframe), so the decision averages a candidate across all
     // channels instead of seeing only the last burst's single-channel sample
@@ -687,12 +692,6 @@ static bool select_gateway_for_handover(uint32_t now_ts, mr_channel_info_t *sele
 
     if (selected_gateway->rssi < (mac_vars.synced_gateway_rssi_ewma + MARI_HANDOVER_RSSI_HYSTERESIS)) {
         // the new gateway is not strong enough, ignore it
-        return false;
-    }
-
-    // FIXME: have this be the first condition to be checked; I put it here just for debugging
-    if (now_ts - mac_vars.synced_ts < MARI_HANDOVER_MIN_INTERVAL) {
-        // just recently performed a synchronization, will not try again so soon
         return false;
     }
 

--- a/firmware/mari/mac.c
+++ b/firmware/mari/mac.c
@@ -672,7 +672,10 @@ static bool select_gateway_for_handover(uint32_t now_ts, mr_channel_info_t *sele
     // channel per slotframe), so the decision averages a candidate across all
     // channels instead of seeing only the last burst's single-channel sample
     uint32_t sweep_duration_us = MARI_N_BLE_ADVERTISING_CHANNELS * mr_scheduler_get_duration_us();
-    if (!mr_scan_select(selected_gateway, now_ts - sweep_duration_us, now_ts)) {
+    // clamp: right after the timer starts (or wraps) now_ts can be smaller than
+    // the sweep duration, and the unsigned underflow would discard every entry
+    uint32_t sweep_started_ts = now_ts > sweep_duration_us ? now_ts - sweep_duration_us : 0;
+    if (!mr_scan_select(selected_gateway, sweep_started_ts, now_ts)) {
         // no gateway found, do nothing
         return false;
     }

--- a/firmware/mari/scan.c
+++ b/firmware/mari/scan.c
@@ -101,8 +101,8 @@ bool mr_scan_select(mr_channel_info_t *best_channel_info, uint32_t ts_scan_start
             continue;
         }
         // compute average rssi, only including the rssi readings that are not too old
-        int8_t avg_rssi = 0;
-        int8_t n_rssi   = 0;
+        int16_t sum_rssi = 0;  // int16: a sum of int8 readings exceeds the int8 range
+        uint8_t n_rssi   = 0;
         for (size_t j = 0; j < MARI_N_BLE_ADVERTISING_CHANNELS; j++) {
             if (scan_vars.scans[i].channel_info[j].timestamp == 0) {  // no scan info reading here
                 continue;
@@ -114,13 +114,13 @@ bool mr_scan_select(mr_channel_info_t *best_channel_info, uint32_t ts_scan_start
             if (ts_scan_ended - scan_vars.scans[i].channel_info[j].timestamp > MARI_SCAN_OLD_US) {  // scan info is is too old
                 continue;
             }
-            avg_rssi += scan_vars.scans[i].channel_info[j].rssi;
+            sum_rssi += scan_vars.scans[i].channel_info[j].rssi;
             n_rssi++;
         }
         if (n_rssi == 0) {
             continue;
         }
-        avg_rssi /= n_rssi;
+        int8_t avg_rssi = (int8_t)(sum_rssi / n_rssi);
         if (avg_rssi > best_gateway_rssi) {
             best_gateway_rssi = avg_rssi;
             best_gateway_idx  = i;
@@ -130,7 +130,10 @@ bool mr_scan_select(mr_channel_info_t *best_channel_info, uint32_t ts_scan_start
         return false;
     }
     *best_channel_info = _get_channel_info_latest(scan_vars.scans[best_gateway_idx]);
-    // TODO: should probably report the average rssi: best_channel_info->rssi = best_gateway_rssi;
+    // report the cross-channel average rssi (a single latest sample can sit in a
+    // per-channel fade); the beacon/timing fields stay from the latest entry,
+    // which synchronization needs as fresh as possible
+    best_channel_info->rssi = best_gateway_rssi;
     return true;
 }
 

--- a/firmware/mari/scan.h
+++ b/firmware/mari/scan.h
@@ -22,7 +22,7 @@
 //=========================== defines =========================================
 
 #define MARI_MAX_SCAN_LIST_SIZE       (5)
-#define MARI_SCAN_OLD_US              (1000 * 500)       // rssi reading considered old after 500 ms
+#define MARI_SCAN_OLD_US              (1000 * 1000)      // rssi reading considered old after 1 s (must cover a full advertising-channel sweep: 3 slotframes, ~770 ms on the huge schedule)
 #define MARI_HANDOVER_RSSI_HYSTERESIS (24)               // hysteresis (in dBm) for handover
 #define MARI_HANDOVER_MIN_INTERVAL    (1000 * 1000 * 5)  // minimum interval between handovers (in us)
 

--- a/firmware/mari/scan.h
+++ b/firmware/mari/scan.h
@@ -23,7 +23,7 @@
 
 #define MARI_MAX_SCAN_LIST_SIZE       (5)
 #define MARI_SCAN_OLD_US              (1000 * 1000)      // rssi reading considered old after 1 s (must cover a full advertising-channel sweep: 3 slotframes, ~770 ms on the huge schedule)
-#define MARI_HANDOVER_RSSI_HYSTERESIS (24)               // hysteresis (in dBm) for handover
+#define MARI_HANDOVER_RSSI_HYSTERESIS (12)               // hysteresis (in dB) for handover; both sides of the comparison are filtered (candidate channel-average, serving ewma)
 #define MARI_HANDOVER_MIN_INTERVAL    (1000 * 1000 * 5)  // minimum interval between handovers (in us)
 #define MARI_HANDOVER_RSSI_EWMA_SHIFT (2)                // serving-gateway rssi smoothing: ewma alpha = 1/2^shift
 

--- a/firmware/mari/scan.h
+++ b/firmware/mari/scan.h
@@ -25,6 +25,7 @@
 #define MARI_SCAN_OLD_US              (1000 * 1000)      // rssi reading considered old after 1 s (must cover a full advertising-channel sweep: 3 slotframes, ~770 ms on the huge schedule)
 #define MARI_HANDOVER_RSSI_HYSTERESIS (24)               // hysteresis (in dBm) for handover
 #define MARI_HANDOVER_MIN_INTERVAL    (1000 * 1000 * 5)  // minimum interval between handovers (in us)
+#define MARI_HANDOVER_RSSI_EWMA_SHIFT (2)                // serving-gateway rssi smoothing: ewma alpha = 1/2^shift
 
 //=========================== variables =======================================
 


### PR DESCRIPTION
The handover gate compared one raw RSSI sample against one raw sample: the
candidate's latest beacon vs whatever packet was heard last (possibly another
gateway's beacon caught in a beacon slot), often measured on different channels.
Indoor single-channel fades run 20-30 dB, so the hysteresis had to be a huge
24 dB to avoid ping-pong - which makes handover so sticky that a node crossing
an overlap zone usually rides its dying link into PEER_LOST_TIMEOUT (~1.3 s
detection plus rejoin) instead of doing a ~0.1 s background-scan switch.

This PR filters both sides of the comparison, then lowers the constant:

- mr_scan_select reports the cross-channel average RSSI, keeping the latest
  entry's beacon/ASN fields (synchronization needs those fresh). Also fixes a
  latent int8 overflow in the averaging sum - invisible until now because the
  old select window never admitted more than one sample.
- The handover selection window spans the full advertising-channel sweep
  (3 slotframes; the bg scan rotates one channel per slotframe) instead of the
  last scan burst, so the average actually forms. MARI_SCAN_OLD_US goes
  500 ms -> 1 s as the staleness backstop, and the window start is clamped at
  timer zero (boot/wrap underflow).
- The serving side is smoothed with an integer EWMA (alpha 1/4) fed only by
  packets from the synced gateway, seeded from the averaged RSSI that won the
  selection - so a foreign packet can no longer stand in for the serving link.
- With both sides filtered, MARI_HANDOVER_RSSI_HYSTERESIS drops 24 -> 12 dB
  (reference points: LTE A3 uses 2-4 dB offsets on filtered measurements,
  Wi-Fi roam deltas are 3-8 dB). MARI_HANDOVER_MIN_INTERVAL stays at 5 s as
  the anti-ping-pong backstop and is now checked before scan selection.

Stacked on #167 (two-perspective handover logging): the first commits here are
that PR's, review the last six. The #167 log rows double as the measurement
instrument for this change - a bench stress test with ~50 nodes shuttled
between two gateways (run with a 9 dB build) exercised the full path: seamless
bg-scan handovers report 0.06-0.15 s node-side vs ~0.44 s cloud-side (uplink
quantization), and dirty handovers are correctly tagged. Before merging, the
12 dB default still wants a stationary mid-point A/B vs 24 dB (ping-pong rate
and clean-vs-dirty share). Builds clean for the nRF52840 node and nRF5340
gateway targets.