### PR TITLE
marilib: improve metrics probe handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,35 @@ make docker      # CI path (Docker-wrapped SEGGER ES)
 
 The project uses SEGGER Embedded Studio `.emProject` files, `clang-format` v15, and `pre-commit` (root config).
 
+### Flash
+
+`firmware/flash.sh` programs connected boards over SWD with `nrfjprog`. It flashes without compiling by default; pass `--build` to build first. Run it with a role and no targets to list what is connected.
+
+```bash
+cd firmware
+./flash.sh node --all                 # every connected nRF52840 node
+./flash.sh gateway <snr>              # one nRF5340 gateway, by J-Link serial
+./flash.sh both --all --build         # build and flash the whole bench
+```
+
+A run only touches its own family (`node` is nRF52840, `gateway` is the dual-core nRF5340), and boards of the other family are listed separately, so flashing nodes cannot wipe a gateway and a board plugged in under the wrong role is easy to spot. Boards that ship with readback protection are recovered automatically.
+
+Useful options: `--net-id <hex>` provisions the gateway's network id into flash after programming (so one image works on any network), `--erase-only` recovers the targets without programming, and `--dry-run` prints the `nrfjprog` commands without running them. `./flash.sh --help` is the full list.
+
+### Schedules
+
+The gateway's schedule is chosen at **compile time** (`schedule_app` in `app/03app_gateway_net/main.c`), so switching it needs a rebuild. Nodes do not: they adopt whatever the beacon advertises, so only the gateway is reflashed.
+
+Since building takes minutes and flashing takes seconds, `build-schedules.sh` builds one gateway net-core image per schedule up front, and `flash.sh --schedule` flashes from that cache:
+
+```bash
+cd firmware
+./build-schedules.sh                  # tiny, medium, big, huge -> Output/schedules/
+./flash.sh gateway --all --schedule tiny
+```
+
+`--schedule` refuses an image older than the firmware sources; add `--build` to refresh that one image. `build-schedules.sh` restores `main.c` byte-for-byte when it finishes or fails, so local uncommitted edits survive the build.
+
 ### Example usage
 
 ```c

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -42,13 +42,65 @@ make node                                    # nrf52840dk node
 make gateway                                 # nRF5340 net-core gateway
 make all                                     # default
 make docker                                  # CI path
-
-SEGGER_DIR=/opt/segger ./flash.sh node|gateway --all|<snr...>
 ```
 
 **No automated test setup.** `app/01mari_*` directories are
 on-target experimental apps, not a unit-test suite. CI only
 verifies it compiles.
+
+## Flashing the bench (`flash.sh`)
+
+Flashes over SWD with `nrfjprog`. Flash-only by default; `--build`
+compiles first. Run with a role and no targets to list what is
+connected.
+
+```bash
+SEGGER_DIR=/opt/segger ./flash.sh <node|gateway|both> --all|<snr...>
+```
+
+- Roles map to families: `node` is nRF52840
+  (`03app_node`), `gateway` is the dual-core nRF5340
+  (`03app_gateway_app` + `03app_gateway_net`). `both` runs the
+  gateway pass then the node pass with the same options, so
+  `both --all --build` does a whole bench in one command.
+- **A run only touches its own family**, and boards of the other
+  family are reported separately, so a missing board is
+  distinguishable from one plugged in under the wrong role.
+  Flashing nodes cannot wipe a gateway. `--force` overrides.
+- Locked (APPROTECT) boards read as UNKNOWN and are auto-recovered.
+  The gateway is recovered on both cores every flash unless
+  `--no-recover`.
+- `--schedule <tiny|medium|big|huge>` flashes the net core from the
+  `build-schedules.sh` cache, and refuses an image older than the
+  sources (add `--build` to refresh just that one, `--force` to
+  flash it anyway).
+- `--net-id <hex>` writes the network id into the net core's config
+  page after programming, which is what makes one image usable on
+  any network. Nodes have no such page: theirs is
+  `MARI_APP_NET_ID` in `03app_node/main.c`.
+- `--erase-only` recovers and stops. `--dry-run` prints every
+  `nrfjprog` command without running it.
+
+## Building the schedule images (`build-schedules.sh`)
+
+The gateway's schedule is a **compile-time** pointer
+(`schedule_app` in `03app_gateway_net/main.c`), so changing it
+means a rebuild. Nodes adopt whatever the beacon advertises, so
+only the gateway is ever reflashed for a schedule change.
+
+Building takes minutes and flashing takes seconds, so build once
+and flash from the cache during a campaign:
+
+```bash
+./build-schedules.sh              # all four -> Output/schedules/
+./build-schedules.sh tiny huge    # just these
+./flash.sh gateway --all --schedule tiny
+```
+
+It edits `main.c` in place and restores it byte-for-byte via an
+EXIT trap, including through a failure. **Uncommitted edits are
+preserved, not discarded** - a bench tree normally carries the
+local net id, so that is the common case, not the exception.
 
 ## Cross-half / cross-repo coupling
 

--- a/firmware/app/03app_gateway_net/metrics.c
+++ b/firmware/app/03app_gateway_net/metrics.c
@@ -10,6 +10,7 @@
  */
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #include "mr_radio.h"
 #include "mac.h"
@@ -39,12 +40,30 @@ void metrics_init(void) {
 }
 
 void metrics_add_node(uint64_t node_id) {
+    // A node already in the table keeps its slot. Adding it twice would take a
+    // second slot for the same node, and the table is only freed by
+    // metrics_clear_node, so every unmatched join leaks one. A gateway that
+    // sees more joins than leaves then fills the table, after which the search
+    // below finds nothing free: the node is never added, its tx_count and
+    // rx_count never increment again, and the probe counters read as though
+    // the gateway had stopped transmitting to a node it is still serving.
     for (uint8_t i = 0; i < MARI_N_CELLS_MAX; i++) {
-        if (metrics_vars.nodes[i].node_id == 0) {
-            metrics_vars.nodes[i].node_id = node_id;
-            break;
+        if (metrics_vars.nodes[i].node_id == node_id) {
+            return;
         }
     }
+    for (uint8_t i = 0; i < MARI_N_CELLS_MAX; i++) {
+        if (metrics_vars.nodes[i].node_id == 0) {
+            metrics_vars.nodes[i].node_id  = node_id;
+            metrics_vars.nodes[i].tx_count = 0;
+            metrics_vars.nodes[i].rx_count = 0;
+            return;
+        }
+    }
+    // Say so rather than carrying on silently: from here every metric this
+    // gateway reports for a newly joined node is wrong, and nothing else in
+    // the system can tell.
+    printf("metrics: node table full (%d), not tracking %016llX\n", MARI_N_CELLS_MAX, node_id);
 }
 
 void metrics_clear_node(uint64_t node_id) {

--- a/firmware/build-schedules.sh
+++ b/firmware/build-schedules.sh
@@ -49,12 +49,20 @@ done
 # normally carries - comes back exactly.
 ORIGINAL="$(mktemp)"
 cp "$MAIN" "$ORIGINAL"
+BUILT=()
 restore() {
   cp "$ORIGINAL" "$MAIN" 2>/dev/null || true
   if cmp -s "$ORIGINAL" "$MAIN"; then
     rm -f "$ORIGINAL"
   else
     echo "WARNING: could not restore $MAIN. Your original is at $ORIGINAL" >&2
+  fi
+  # The restore writes main.c after the images were produced from it, so
+  # without this every image ends up older than the source it was built from,
+  # and anything comparing the two reads a fresh build as stale. Stamping them
+  # here, after the restore, is the only point at which they are last.
+  if [[ ${#BUILT[@]} -gt 0 ]]; then
+    touch "${BUILT[@]}"
   fi
 }
 trap restore EXIT
@@ -75,6 +83,7 @@ for sched in "${SCHEDULES[@]}"; do
 
   SEGGER_DIR="$SEGGER_DIR" BUILD_CONFIG="$BUILD_CONFIG" make -C "$FW_DIR" gateway-net
   cp "$BUILT_HEX" "$OUT_DIR/03app_gateway_net-${sched}.hex"
+  BUILT+=("$OUT_DIR/03app_gateway_net-${sched}.hex")
   echo "  -> $OUT_DIR/03app_gateway_net-${sched}.hex"
   echo
 done

--- a/firmware/build-schedules.sh
+++ b/firmware/build-schedules.sh
@@ -14,9 +14,11 @@
 #   ./build-schedules.sh tiny huge             # just these
 #   ./flash.sh gateway --all --net-hex Output/schedules/03app_gateway_net-tiny.hex
 #
-# main.c is edited in place and restored by an EXIT trap, so an interrupted run
-# does not leave the source pointing at the wrong schedule. It refuses to start
-# if the file is already modified, rather than restoring someone else's edit.
+# main.c is edited in place and restored byte-for-byte from a copy taken up
+# front, via an EXIT trap, so an interrupted run does not leave the source
+# pointing at the wrong schedule. Uncommitted edits are preserved, not
+# discarded - the bench net id lives in this very file, so that is the normal
+# case rather than the exception.
 #
 # Env:
 #   SEGGER_DIR    SES install (default: /opt/segger)
@@ -42,17 +44,19 @@ for s in "${SCHEDULES[@]}"; do
   esac
 done
 
-# Refuse to touch a file someone else is already editing: the restore below
-# would silently revert their change.
-if ! git -C "$FW_DIR" diff --quiet -- "$MAIN" 2>/dev/null; then
-  echo "Error: $(basename "$MAIN") has uncommitted changes." >&2
-  echo "       This script rewrites and restores it, which would discard them." >&2
-  exit 1
-fi
-
+# Snapshot before touching anything. The restore is byte-for-byte from this
+# copy, so whatever state main.c was in - including the uncommitted net id it
+# normally carries - comes back exactly.
 ORIGINAL="$(mktemp)"
 cp "$MAIN" "$ORIGINAL"
-restore() { cp "$ORIGINAL" "$MAIN"; rm -f "$ORIGINAL"; }
+restore() {
+  cp "$ORIGINAL" "$MAIN" 2>/dev/null || true
+  if cmp -s "$ORIGINAL" "$MAIN"; then
+    rm -f "$ORIGINAL"
+  else
+    echo "WARNING: could not restore $MAIN. Your original is at $ORIGINAL" >&2
+  fi
+}
 trap restore EXIT
 
 mkdir -p "$OUT_DIR"

--- a/firmware/build-schedules.sh
+++ b/firmware/build-schedules.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# build-schedules.sh - build one gateway net-core image per schedule.
+#
+# The gateway's schedule is a compile-time pointer (03app_gateway_net/main.c,
+# `schedule_app`), so switching it means a rebuild. Nodes do not: they adopt
+# whatever the beacon advertises (mari/mac.c, sync_to_gateway ->
+# mr_scheduler_set_schedule), so only the gateway is ever reflashed.
+#
+# Building takes minutes and flashing takes seconds, so build all of them once
+# and flash from the cache during a campaign:
+#
+#   ./build-schedules.sh                       # all four, into Output/schedules/
+#   ./build-schedules.sh tiny huge             # just these
+#   ./flash.sh gateway --all --net-hex Output/schedules/03app_gateway_net-tiny.hex
+#
+# main.c is edited in place and restored by an EXIT trap, so an interrupted run
+# does not leave the source pointing at the wrong schedule. It refuses to start
+# if the file is already modified, rather than restoring someone else's edit.
+#
+# Env:
+#   SEGGER_DIR    SES install (default: /opt/segger)
+#   BUILD_CONFIG  SES config (default: Debug)
+
+set -euo pipefail
+
+SEGGER_DIR="${SEGGER_DIR:-/opt/segger}"
+BUILD_CONFIG="${BUILD_CONFIG:-Debug}"
+
+FW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIN="$FW_DIR/app/03app_gateway_net/main.c"
+OUT_DIR="$FW_DIR/Output/schedules"
+BUILT_HEX="$FW_DIR/app/03app_gateway_net/Output/nrf5340-net/$BUILD_CONFIG/Exe/03app_gateway_net-nrf5340-net.hex"
+
+SCHEDULES=("$@")
+[[ ${#SCHEDULES[@]} -eq 0 ]] && SCHEDULES=(tiny medium big huge)
+
+for s in "${SCHEDULES[@]}"; do
+  case "$s" in
+    tiny|medium|big|huge) ;;
+    *) echo "Error: unknown schedule '$s' (tiny|medium|big|huge)" >&2; exit 2 ;;
+  esac
+done
+
+# Refuse to touch a file someone else is already editing: the restore below
+# would silently revert their change.
+if ! git -C "$FW_DIR" diff --quiet -- "$MAIN" 2>/dev/null; then
+  echo "Error: $(basename "$MAIN") has uncommitted changes." >&2
+  echo "       This script rewrites and restores it, which would discard them." >&2
+  exit 1
+fi
+
+ORIGINAL="$(mktemp)"
+cp "$MAIN" "$ORIGINAL"
+restore() { cp "$ORIGINAL" "$MAIN"; rm -f "$ORIGINAL"; }
+trap restore EXIT
+
+mkdir -p "$OUT_DIR"
+echo "Building ${#SCHEDULES[@]} gateway net-core image(s) into $OUT_DIR"
+echo
+
+for sched in "${SCHEDULES[@]}"; do
+  echo "=== $sched ==="
+  # Only the schedule_app line: a blanket substitution would also rewrite the
+  # extern declaration on the line above it.
+  sed -i '' -E "s/^(schedule_t[[:space:]]+\*schedule_app[[:space:]]*=[[:space:]]*&)schedule_[a-z]+;/\1schedule_${sched};/" "$MAIN"
+  if ! grep -qE "^schedule_t[[:space:]]+\*schedule_app[[:space:]]*=[[:space:]]*&schedule_${sched};" "$MAIN"; then
+    echo "Error: could not point schedule_app at schedule_${sched}" >&2
+    exit 1
+  fi
+
+  SEGGER_DIR="$SEGGER_DIR" BUILD_CONFIG="$BUILD_CONFIG" make -C "$FW_DIR" gateway-net
+  cp "$BUILT_HEX" "$OUT_DIR/03app_gateway_net-${sched}.hex"
+  echo "  -> $OUT_DIR/03app_gateway_net-${sched}.hex"
+  echo
+done
+
+echo "Done."
+shasum -a 256 "$OUT_DIR"/*.hex | sed 's/^/  /'

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -81,6 +81,11 @@ TARGETS=()
 PASSTHRU=()
 
 while [[ $# -gt 0 ]]; do
+  # A flag that takes a value consumes two argv items, and `both` replays what
+  # it did not consume itself, so the flag and its value have to be recorded
+  # together or the replayed pass sees a bare value and reads it as a serial.
+  arg="$1"
+  took_value=0
   case "$1" in
     --build)      DO_BUILD=1 ;;
     --erase-only) ERASE=1 ;;
@@ -89,11 +94,11 @@ while [[ $# -gt 0 ]]; do
     --force)      FORCE=1 ;;
     --dry-run)    DRY_RUN=1 ;;
     --all)        ALL=1 ;;
-    --hex)        shift; HEX_NODE="${1:-}"; [[ -z "$HEX_NODE" ]] && { echo "Error: --hex needs a path" >&2; exit 2; } ;;
+    --hex)        shift; HEX_NODE="${1:-}"; took_value=1; [[ -z "$HEX_NODE" ]] && { echo "Error: --hex needs a path" >&2; exit 2; } ;;
     --hex=*)      HEX_NODE="${1#--hex=}" ;;
-    --app-hex)    shift; HEX_APP="${1:-}"; [[ -z "$HEX_APP" ]] && { echo "Error: --app-hex needs a path" >&2; exit 2; } ;;
+    --app-hex)    shift; HEX_APP="${1:-}"; took_value=1; [[ -z "$HEX_APP" ]] && { echo "Error: --app-hex needs a path" >&2; exit 2; } ;;
     --app-hex=*)  HEX_APP="${1#--app-hex=}" ;;
-    --net-hex)    shift; HEX_NET="${1:-}"; [[ -z "$HEX_NET" ]] && { echo "Error: --net-hex needs a path" >&2; exit 2; } ;;
+    --net-hex)    shift; HEX_NET="${1:-}"; took_value=1; [[ -z "$HEX_NET" ]] && { echo "Error: --net-hex needs a path" >&2; exit 2; } ;;
     --net-hex=*)  HEX_NET="${1#--net-hex=}" ;;
     -h|--help)    awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
     node|gateway|both) [[ -n "$ROLE" ]] && { echo "Error: role already set to '$ROLE'" >&2; exit 2; }; ROLE="$1" ;;
@@ -101,9 +106,9 @@ while [[ $# -gt 0 ]]; do
     *)            TARGETS+=("$1") ;;
   esac
   # Everything except the role is replayed verbatim by the `both` pass below.
-  case "$1" in
+  case "$arg" in
     node|gateway|both) ;;
-    *) PASSTHRU+=("$1") ;;
+    *) if [[ "$took_value" -eq 1 ]]; then PASSTHRU+=("$arg" "$1"); else PASSTHRU+=("$arg"); fi ;;
   esac
   shift
 done
@@ -121,8 +126,22 @@ fi
 if [[ "$ROLE" == both ]]; then
   for r in gateway node; do
     echo "================================ $r ================================"
+    # An image flag belongs to one role and is an error in the other, so each
+    # pass gets the arguments that mean something to it rather than all of them.
+    ARGS=()
+    SKIP_VALUE=0
     if [[ ${#PASSTHRU[@]} -gt 0 ]]; then
-      "$0" "$r" "${PASSTHRU[@]}"
+      for a in "${PASSTHRU[@]}"; do
+        if [[ "$SKIP_VALUE" -eq 1 ]]; then SKIP_VALUE=0; continue; fi
+        case "$r:$a" in
+          node:--app-hex|node:--net-hex|gateway:--hex) SKIP_VALUE=1; continue ;;
+          node:--app-hex=*|node:--net-hex=*|gateway:--hex=*) continue ;;
+        esac
+        ARGS+=("$a")
+      done
+    fi
+    if [[ ${#ARGS[@]} -gt 0 ]]; then
+      "$0" "$r" "${ARGS[@]}"
     else
       "$0" "$r"
     fi

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -45,6 +45,13 @@
 #   --hex <file>      node only:    flash this hex instead of the default
 #   --app-hex <file>  gateway only: app-core hex override
 #   --net-hex <file>  gateway only: net-core hex override
+#   --schedule <s>    gateway only: net-core image for the tiny|medium|big|huge
+#                     schedule, from the Output/schedules/ cache that
+#                     build-schedules.sh fills. The schedule is a compile-time
+#                     pointer, so naming it here is the same thing as naming
+#                     the image it produced - and the cache is only as current
+#                     as the last build-schedules.sh run, which is why a
+#                     missing image is an error rather than a rebuild.
 #   --erase-only      erase only: recover the targets and stop, no programming.
 #                     On the dual-core gateway that is both cores, which is the
 #                     pair of nrfjprog calls you would otherwise run by hand.
@@ -77,6 +84,7 @@ ROLE=""
 HEX_NODE=""
 HEX_APP=""
 HEX_NET=""
+SCHEDULE=""
 TARGETS=()
 PASSTHRU=()
 
@@ -100,6 +108,8 @@ while [[ $# -gt 0 ]]; do
     --app-hex=*)  HEX_APP="${1#--app-hex=}" ;;
     --net-hex)    shift; HEX_NET="${1:-}"; took_value=1; [[ -z "$HEX_NET" ]] && { echo "Error: --net-hex needs a path" >&2; exit 2; } ;;
     --net-hex=*)  HEX_NET="${1#--net-hex=}" ;;
+    --schedule)   shift; SCHEDULE="${1:-}"; took_value=1; [[ -z "$SCHEDULE" ]] && { echo "Error: --schedule needs one of tiny|medium|big|huge" >&2; exit 2; } ;;
+    --schedule=*) SCHEDULE="${1#--schedule=}" ;;
     -h|--help)    awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
     node|gateway|both) [[ -n "$ROLE" ]] && { echo "Error: role already set to '$ROLE'" >&2; exit 2; }; ROLE="$1" ;;
     -*)           echo "Unknown option: $1" >&2; exit 2 ;;
@@ -134,8 +144,8 @@ if [[ "$ROLE" == both ]]; then
       for a in "${PASSTHRU[@]}"; do
         if [[ "$SKIP_VALUE" -eq 1 ]]; then SKIP_VALUE=0; continue; fi
         case "$r:$a" in
-          node:--app-hex|node:--net-hex|gateway:--hex) SKIP_VALUE=1; continue ;;
-          node:--app-hex=*|node:--net-hex=*|gateway:--hex=*) continue ;;
+          node:--app-hex|node:--net-hex|node:--schedule|gateway:--hex) SKIP_VALUE=1; continue ;;
+          node:--app-hex=*|node:--net-hex=*|node:--schedule=*|gateway:--hex=*) continue ;;
         esac
         ARGS+=("$a")
       done
@@ -174,6 +184,7 @@ case "$ROLE" in
     MULTICORE=0
     MAKE_TARGET="node"
     [[ -n "$HEX_APP$HEX_NET" ]] && { echo "Error: --app-hex/--net-hex are gateway-only; use --hex for node" >&2; exit 2; }
+    [[ -n "$SCHEDULE" ]] && { echo "Error: --schedule is gateway-only; nodes adopt whatever the beacon advertises" >&2; exit 2; }
     HEX_APP="${HEX_NODE:-$FW_DIR/app/03app_node/Output/nrf52840dk/$BUILD_CONFIG/Exe/03app_node-nrf52840dk.hex}"
     HEX_NET=""
     ;;
@@ -183,6 +194,21 @@ case "$ROLE" in
     MULTICORE=1
     MAKE_TARGET="gateway"
     [[ -n "$HEX_NODE" ]] && { echo "Error: --hex is node-only; use --app-hex/--net-hex for gateway" >&2; exit 2; }
+    if [[ -n "$SCHEDULE" ]]; then
+      [[ -n "$HEX_NET" ]] && { echo "Error: --schedule and --net-hex both name the net-core image; pass one" >&2; exit 2; }
+      [[ "$DO_BUILD" -eq 1 ]] && { echo "Error: --build compiles a net core, --schedule flashes a prebuilt one; pass one" >&2; exit 2; }
+      case "$SCHEDULE" in
+        tiny|medium|big|huge) ;;
+        *) echo "Error: unknown schedule '$SCHEDULE' (tiny|medium|big|huge)" >&2; exit 2 ;;
+      esac
+      HEX_NET="$FW_DIR/Output/schedules/03app_gateway_net-$SCHEDULE.hex"
+      if [[ ! -f "$HEX_NET" ]]; then
+        echo "Error: no image for the $SCHEDULE schedule at $HEX_NET" >&2
+        echo "       Build the cache first: $FW_DIR/build-schedules.sh $SCHEDULE" >&2
+        exit 2
+      fi
+      echo "net core: $SCHEDULE schedule, built $(date -r "$HEX_NET" '+%Y-%m-%d %H:%M')"
+    fi
     HEX_APP="${HEX_APP:-$FW_DIR/app/03app_gateway_app/Output/nrf5340-app/$BUILD_CONFIG/Exe/03app_gateway_app-nrf5340-app.hex}"
     HEX_NET="${HEX_NET:-$FW_DIR/app/03app_gateway_net/Output/nrf5340-net/$BUILD_CONFIG/Exe/03app_gateway_net-nrf5340-net.hex}"
     ;;

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -52,6 +52,11 @@
 #                     the image it produced. Refuses to flash an image older
 #                     than the firmware sources: add --build to rebuild that
 #                     one image first, or --force to flash it as it is.
+#   --net-id <hex>    gateway only: provision the network id (16-bit hex, e.g.
+#                     a000) into the net core's config page after programming,
+#                     overriding the compile-time fallback. The value is read
+#                     back and printed. Nodes have no such page; theirs is
+#                     MARI_APP_NET_ID in 03app_node/main.c
 #   --erase-only      erase only: recover the targets and stop, no programming.
 #                     On the dual-core gateway that is both cores, which is the
 #                     pair of nrfjprog calls you would otherwise run by hand.
@@ -88,7 +93,16 @@ HEX_NODE=""
 HEX_APP=""
 HEX_NET=""
 SCHEDULE=""
+NET_ID=""
 TARGETS=()
+
+# The gateway net core reads its network id from a packed
+# {magic, has_net_id, net_id} of uint32 in the last 2 KB page of its own flash,
+# falling back to a compile-time constant when the magic is absent
+# (03app_gateway_net/main.c). Writing it here is what makes one image usable on
+# any network.
+NET_CFG_ADDR="0x0103F800"
+NET_CFG_MAGIC="0x5753524D"
 PASSTHRU=()
 
 while [[ $# -gt 0 ]]; do
@@ -113,6 +127,8 @@ while [[ $# -gt 0 ]]; do
     --net-hex=*)  HEX_NET="${1#--net-hex=}" ;;
     --schedule)   shift; SCHEDULE="${1:-}"; took_value=1; [[ -z "$SCHEDULE" ]] && { echo "Error: --schedule needs one of tiny|medium|big|huge" >&2; exit 2; } ;;
     --schedule=*) SCHEDULE="${1#--schedule=}" ;;
+    --net-id)     shift; NET_ID="${1:-}"; took_value=1; [[ -z "$NET_ID" ]] && { echo "Error: --net-id needs a 16-bit hex value, e.g. a000" >&2; exit 2; } ;;
+    --net-id=*)   NET_ID="${1#--net-id=}" ;;
     -h|--help)    awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
     node|gateway|both) [[ -n "$ROLE" ]] && { echo "Error: role already set to '$ROLE'" >&2; exit 2; }; ROLE="$1" ;;
     -*)           echo "Unknown option: $1" >&2; exit 2 ;;
@@ -147,8 +163,8 @@ if [[ "$ROLE" == both ]]; then
       for a in "${PASSTHRU[@]}"; do
         if [[ "$SKIP_VALUE" -eq 1 ]]; then SKIP_VALUE=0; continue; fi
         case "$r:$a" in
-          node:--app-hex|node:--net-hex|node:--schedule|gateway:--hex) SKIP_VALUE=1; continue ;;
-          node:--app-hex=*|node:--net-hex=*|node:--schedule=*|gateway:--hex=*) continue ;;
+          node:--app-hex|node:--net-hex|node:--schedule|node:--net-id|gateway:--hex) SKIP_VALUE=1; continue ;;
+          node:--app-hex=*|node:--net-hex=*|node:--schedule=*|node:--net-id=*|gateway:--hex=*) continue ;;
         esac
         ARGS+=("$a")
       done
@@ -188,6 +204,7 @@ case "$ROLE" in
     MAKE_TARGET="node"
     [[ -n "$HEX_APP$HEX_NET" ]] && { echo "Error: --app-hex/--net-hex are gateway-only; use --hex for node" >&2; exit 2; }
     [[ -n "$SCHEDULE" ]] && { echo "Error: --schedule is gateway-only; nodes adopt whatever the beacon advertises" >&2; exit 2; }
+    [[ -n "$NET_ID" ]] && { echo "Error: --net-id is gateway-only; the node's is a compile-time constant (MARI_APP_NET_ID)" >&2; exit 2; }
     HEX_APP="${HEX_NODE:-$FW_DIR/app/03app_node/Output/nrf52840dk/$BUILD_CONFIG/Exe/03app_node-nrf52840dk.hex}"
     HEX_NET=""
     ;;
@@ -204,6 +221,17 @@ case "$ROLE" in
         *) echo "Error: unknown schedule '$SCHEDULE' (tiny|medium|big|huge)" >&2; exit 2 ;;
       esac
       HEX_NET="$FW_DIR/Output/schedules/03app_gateway_net-$SCHEDULE.hex"
+    fi
+    if [[ -n "$NET_ID" ]]; then
+      [[ "$ERASE" -eq 1 ]] && { echo "Error: --erase-only leaves no firmware to read a network id" >&2; exit 2; }
+      NET_ID="${NET_ID#0x}"; NET_ID="${NET_ID#0X}"
+      if ! [[ "$NET_ID" =~ ^[0-9a-fA-F]{1,4}$ ]]; then
+        echo "Error: --net-id takes a 16-bit hex value, e.g. a000 or 0xA000; got '$NET_ID'" >&2
+        exit 2
+      fi
+      # printf rather than ${x^^}: bash 3.2 (macOS) has no case conversion.
+      NET_ID="$(printf '%04X' "0x$NET_ID")"
+      [[ "$NET_ID" == "0000" ]] && { echo "Error: --net-id 0 is not a network" >&2; exit 2; }
     fi
     HEX_APP="${HEX_APP:-$FW_DIR/app/03app_gateway_app/Output/nrf5340-app/$BUILD_CONFIG/Exe/03app_gateway_app-nrf5340-app.hex}"
     HEX_NET="${HEX_NET:-$FW_DIR/app/03app_gateway_net/Output/nrf5340-net/$BUILD_CONFIG/Exe/03app_gateway_net-nrf5340-net.hex}"
@@ -426,6 +454,19 @@ for snr in "${TO_FLASH[@]}"; do
     # App core first, then net core - mirrors dotbot device's gateway flow.
     run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_APPLICATION --program "$HEX_APP" --chiperase --verify --reset
     run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --program "$HEX_NET" --chiperase --verify --reset
+    if [[ -n "$NET_ID" ]]; then
+      # The page is erased explicitly rather than relying on the --chiperase
+      # above, so provisioning behaves the same whether or not this run also
+      # reprogrammed the core. The reset at the end is what makes the net core
+      # read the id it was just given.
+      echo "  provisioning network id 0x$NET_ID ..."
+      run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --erasepage "$NET_CFG_ADDR"
+      run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --memwr "$NET_CFG_ADDR" --val "$NET_CFG_MAGIC"
+      run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --memwr "$(printf '0x%08X' $((NET_CFG_ADDR + 4)))" --val 0x00000001
+      run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --memwr "$(printf '0x%08X' $((NET_CFG_ADDR + 8)))" --val "0x0000$NET_ID"
+      run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --memrd "$NET_CFG_ADDR" --n 12
+      run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --coprocessor CP_NETWORK --reset
+    fi
   else
     run_cmd nrfjprog -f "$NRF_FAMILY" -s "$snr" --program "$HEX_APP" --sectorerase --verify --reset
   fi

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -134,16 +134,40 @@ if [[ -z "$CONNECTED" ]]; then
   exit 1
 fi
 
-# No selector given: show what's on the bench and bail.
+# No selector given: show what's on the bench and bail. Listed per role, the
+# same way flashing treats them: only this role's family is a candidate, and a
+# locked board counts as one because it cannot be identified until it has been
+# recovered. Everything else is reported separately, so a missing board is
+# distinguishable from one plugged in under the other role.
 if [[ "$ALL" -eq 0 && ${#TARGETS[@]} -eq 0 ]]; then
-  echo "Connected J-Link serials:"
+  MATCHES=()
+  OTHERS=()
   while read -r snr; do
     [[ -z "$snr" ]] && continue
-    fam="$(nrfjprog --snr "$snr" --deviceversion 2>/dev/null || echo '???')"
-    printf '  %s  (%s)\n' "$snr" "$fam"
+    fam="$(nrfjprog --snr "$snr" --deviceversion 2>/dev/null || echo 'UNKNOWN')"
+    if [[ "$fam" == $EXPECT_GLOB ]]; then
+      MATCHES+=("$snr  ($fam)")
+    elif [[ "$fam" == UNKNOWN ]]; then
+      MATCHES+=("$snr  (locked or unreadable; would be recovered as $ROLE)")
+    else
+      OTHERS+=("$snr  ($fam)")
+    fi
   done <<< "$CONNECTED"
-  echo
-  echo "Re-run with --all or one/more of the serials above."
+
+  if [[ ${#MATCHES[@]} -gt 0 ]]; then
+    echo "Connected $EXPECT_GLOB devices for role '$ROLE':"
+    printf '  %s\n' "${MATCHES[@]}"
+    echo
+    echo "Re-run with --all or one/more of the serials above."
+  else
+    echo "No $EXPECT_GLOB device connected for role '$ROLE'."
+  fi
+
+  if [[ ${#OTHERS[@]} -gt 0 ]]; then
+    echo
+    echo "Not for this role (wrong family, would be skipped):"
+    printf '  %s\n' "${OTHERS[@]}"
+  fi
   exit 0
 fi
 

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -49,16 +49,19 @@
 #                     schedule, from the Output/schedules/ cache that
 #                     build-schedules.sh fills. The schedule is a compile-time
 #                     pointer, so naming it here is the same thing as naming
-#                     the image it produced - and the cache is only as current
-#                     as the last build-schedules.sh run, which is why a
-#                     missing image is an error rather than a rebuild.
+#                     the image it produced. Refuses to flash an image older
+#                     than the firmware sources: add --build to rebuild that
+#                     one image first, or --force to flash it as it is.
 #   --erase-only      erase only: recover the targets and stop, no programming.
 #                     On the dual-core gateway that is both cores, which is the
 #                     pair of nrfjprog calls you would otherwise run by hand.
-#   --build           (re)build the role first (default: flash only, no compile)
+#   --build           (re)build first (default: flash only, no compile). With
+#                     --schedule that is the one cached image, via
+#                     build-schedules.sh, rather than the role's default output
 #   --recover         force a clean-slate recover before flashing
 #   --no-recover      skip recover even on the gateway (which recovers by default)
-#   --force           flash even if the target isn't the role's expected family
+#   --force           flash anyway when a check would stop you: a target that
+#                     isn't the role's expected family, or a stale --schedule image
 #   --dry-run         print every nrfjprog command without running it
 #
 # Env:
@@ -196,18 +199,11 @@ case "$ROLE" in
     [[ -n "$HEX_NODE" ]] && { echo "Error: --hex is node-only; use --app-hex/--net-hex for gateway" >&2; exit 2; }
     if [[ -n "$SCHEDULE" ]]; then
       [[ -n "$HEX_NET" ]] && { echo "Error: --schedule and --net-hex both name the net-core image; pass one" >&2; exit 2; }
-      [[ "$DO_BUILD" -eq 1 ]] && { echo "Error: --build compiles a net core, --schedule flashes a prebuilt one; pass one" >&2; exit 2; }
       case "$SCHEDULE" in
         tiny|medium|big|huge) ;;
         *) echo "Error: unknown schedule '$SCHEDULE' (tiny|medium|big|huge)" >&2; exit 2 ;;
       esac
       HEX_NET="$FW_DIR/Output/schedules/03app_gateway_net-$SCHEDULE.hex"
-      if [[ ! -f "$HEX_NET" ]]; then
-        echo "Error: no image for the $SCHEDULE schedule at $HEX_NET" >&2
-        echo "       Build the cache first: $FW_DIR/build-schedules.sh $SCHEDULE" >&2
-        exit 2
-      fi
-      echo "net core: $SCHEDULE schedule, built $(date -r "$HEX_NET" '+%Y-%m-%d %H:%M')"
     fi
     HEX_APP="${HEX_APP:-$FW_DIR/app/03app_gateway_app/Output/nrf5340-app/$BUILD_CONFIG/Exe/03app_gateway_app-nrf5340-app.hex}"
     HEX_NET="${HEX_NET:-$FW_DIR/app/03app_gateway_net/Output/nrf5340-net/$BUILD_CONFIG/Exe/03app_gateway_net-nrf5340-net.hex}"
@@ -277,10 +273,44 @@ else
   done
 fi
 
-# Build the role (unless skipped).
+# Build the role (unless skipped). With --schedule the target is one net-core
+# image in the cache rather than the role's default output, and only
+# build-schedules.sh knows how to produce that: it flips the compile-time
+# schedule pointer, builds, and files the result under its schedule's name.
 if [[ "$DO_BUILD" -eq 1 && "$ERASE" -eq 0 ]]; then
-  echo "Building Mari $ROLE ($BUILD_CONFIG) ..."
-  SEGGER_DIR="$SEGGER_DIR" BUILD_CONFIG="$BUILD_CONFIG" make -C "$FW_DIR" "$MAKE_TARGET"
+  if [[ -n "$SCHEDULE" ]]; then
+    echo "Building the $SCHEDULE net-core image ($BUILD_CONFIG) ..."
+    SEGGER_DIR="$SEGGER_DIR" BUILD_CONFIG="$BUILD_CONFIG" "$FW_DIR/build-schedules.sh" "$SCHEDULE"
+  else
+    echo "Building Mari $ROLE ($BUILD_CONFIG) ..."
+    SEGGER_DIR="$SEGGER_DIR" BUILD_CONFIG="$BUILD_CONFIG" make -C "$FW_DIR" "$MAKE_TARGET"
+  fi
+fi
+
+# A cached schedule image is only as current as the last build-schedules.sh
+# run, and flashing a stale one puts old firmware on the gateway without
+# leaving a trace in the measurements it goes on to produce. So this stops
+# rather than warns: a campaign runner invokes this script with its output
+# captured and shows it only on a non-zero exit, where a warning would be seen
+# by nobody.
+if [[ -n "$SCHEDULE" && "$ERASE" -eq 0 ]]; then
+  if [[ ! -f "$HEX_NET" ]]; then
+    echo "Error: no image for the $SCHEDULE schedule at $HEX_NET" >&2
+    echo "       Re-run with --build, or build it: $FW_DIR/build-schedules.sh $SCHEDULE" >&2
+    exit 1
+  fi
+  NEWER="$(find "$FW_DIR/app" "$FW_DIR/mari" "$FW_DIR/drv" "$FW_DIR/nRF" \
+                -type d -name Output -prune -o \
+                -type f \( -name '*.c' -o -name '*.h' -o -name '*.emProject' \) \
+                -newer "$HEX_NET" -print 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$NEWER" && "$FORCE" -eq 0 ]]; then
+    echo "Error: the $SCHEDULE image is older than the firmware sources." >&2
+    echo "       image:  $(date -r "$HEX_NET" '+%Y-%m-%d %H:%M')  ${HEX_NET#"$FW_DIR"/}" >&2
+    echo "       source: $(date -r "$NEWER" '+%Y-%m-%d %H:%M')  ${NEWER#"$FW_DIR"/}" >&2
+    echo "       Re-run with --build to rebuild it, or --force to flash it as it is." >&2
+    exit 1
+  fi
+  echo "net core: $SCHEDULE schedule, built $(date -r "$HEX_NET" '+%Y-%m-%d %H:%M')"
 fi
 
 # Hex presence check. Skipped when erasing: there is nothing to program, and

--- a/firmware/flash.sh
+++ b/firmware/flash.sh
@@ -32,14 +32,22 @@
 # for.
 #
 # Usage:
-#   ./flash.sh <node|gateway> --all              flash every matching connected board
-#   ./flash.sh <node|gateway> <snr> [<snr> ...]  flash specific J-Link serials
-#   ./flash.sh <node|gateway>                    list connected devices, then exit
+#   ./flash.sh <node|gateway|both> --all              flash every matching connected board
+#   ./flash.sh <node|gateway|both> <snr> [<snr> ...]  flash specific J-Link serials
+#   ./flash.sh <node|gateway|both>                    list connected devices, then exit
+#
+# `both` runs the gateway pass then the node pass with the same options. Since
+# each pass only touches its own family, `./flash.sh both --all --build` builds
+# and flashes everything connected in one command, routing each board by the
+# family it reports.
 #
 # Options:
 #   --hex <file>      node only:    flash this hex instead of the default
 #   --app-hex <file>  gateway only: app-core hex override
 #   --net-hex <file>  gateway only: net-core hex override
+#   --erase-only      erase only: recover the targets and stop, no programming.
+#                     On the dual-core gateway that is both cores, which is the
+#                     pair of nrfjprog calls you would otherwise run by hand.
 #   --build           (re)build the role first (default: flash only, no compile)
 #   --recover         force a clean-slate recover before flashing
 #   --no-recover      skip recover even on the gateway (which recovers by default)
@@ -59,6 +67,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FW_DIR="$SCRIPT_DIR"
 
 DO_BUILD=0
+ERASE=0
 FORCE=0
 DRY_RUN=0
 RECOVER=0
@@ -69,10 +78,12 @@ HEX_NODE=""
 HEX_APP=""
 HEX_NET=""
 TARGETS=()
+PASSTHRU=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --build)      DO_BUILD=1 ;;
+    --erase-only) ERASE=1 ;;
     --recover)    RECOVER=1 ;;
     --no-recover) NO_RECOVER=1 ;;
     --force)      FORCE=1 ;;
@@ -85,21 +96,53 @@ while [[ $# -gt 0 ]]; do
     --net-hex)    shift; HEX_NET="${1:-}"; [[ -z "$HEX_NET" ]] && { echo "Error: --net-hex needs a path" >&2; exit 2; } ;;
     --net-hex=*)  HEX_NET="${1#--net-hex=}" ;;
     -h|--help)    awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
-    node|gateway) [[ -n "$ROLE" ]] && { echo "Error: role already set to '$ROLE'" >&2; exit 2; }; ROLE="$1" ;;
+    node|gateway|both) [[ -n "$ROLE" ]] && { echo "Error: role already set to '$ROLE'" >&2; exit 2; }; ROLE="$1" ;;
     -*)           echo "Unknown option: $1" >&2; exit 2 ;;
     *)            TARGETS+=("$1") ;;
+  esac
+  # Everything except the role is replayed verbatim by the `both` pass below.
+  case "$1" in
+    node|gateway|both) ;;
+    *) PASSTHRU+=("$1") ;;
   esac
   shift
 done
 
 if [[ -z "$ROLE" ]]; then
-  echo "Error: first argument must be a role: node | gateway" >&2
-  echo "  e.g. ./flash.sh node --all   /   ./flash.sh gateway <snr>" >&2
+  echo "Error: first argument must be a role: node | gateway | both" >&2
+  echo "  e.g. ./flash.sh node --all   /   ./flash.sh both --all --build" >&2
   exit 2
+fi
+
+# `both` is the two passes back to back. Re-invoking rather than looping inside
+# keeps every per-role code path below exactly as it is when run alone, and the
+# family guard means each board is picked up by the pass that matches it.
+# set -e stops at the first failing pass.
+if [[ "$ROLE" == both ]]; then
+  for r in gateway node; do
+    echo "================================ $r ================================"
+    if [[ ${#PASSTHRU[@]} -gt 0 ]]; then
+      "$0" "$r" "${PASSTHRU[@]}"
+    else
+      "$0" "$r"
+    fi
+    echo
+  done
+  exit 0
 fi
 
 if [[ "$RECOVER" -eq 1 && "$NO_RECOVER" -eq 1 ]]; then
   echo "Error: --recover and --no-recover are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$ERASE" -eq 1 && "$NO_RECOVER" -eq 1 ]]; then
+  echo "Error: --erase-only and --no-recover contradict each other" >&2
+  exit 2
+fi
+
+if [[ "$ERASE" -eq 1 && "$DO_BUILD" -eq 1 ]]; then
+  echo "Error: --erase-only does not program anything, so --build has nothing to do" >&2
   exit 2
 fi
 
@@ -190,26 +233,44 @@ else
 fi
 
 # Build the role (unless skipped).
-if [[ "$DO_BUILD" -eq 1 ]]; then
+if [[ "$DO_BUILD" -eq 1 && "$ERASE" -eq 0 ]]; then
   echo "Building Mari $ROLE ($BUILD_CONFIG) ..."
   SEGGER_DIR="$SEGGER_DIR" BUILD_CONFIG="$BUILD_CONFIG" make -C "$FW_DIR" "$MAKE_TARGET"
 fi
 
-# Hex presence check.
-for h in "$HEX_APP" $HEX_NET; do
-  if [[ ! -f "$h" ]]; then
-    echo "Error: hex not found: $h" >&2
-    echo "       (pass an explicit hex, or --build to compile it first)" >&2
-    exit 1
-  fi
-done
+# Hex presence check. Skipped when erasing: there is nothing to program, and
+# requiring a build artifact to wipe a board would be nonsense.
+if [[ "$ERASE" -eq 0 ]]; then
+  for h in "$HEX_APP" $HEX_NET; do
+    if [[ ! -f "$h" ]]; then
+      echo "Error: hex not found: $h" >&2
+      echo "       (pass an explicit hex, or --build to compile it first)" >&2
+      exit 1
+    fi
+  done
+fi
+
+# Identify each image by name AND content: two builds of the same source land
+# at the same path, so only the checksum tells you whether the boards in front
+# of you are running the same binary.
+hex_line() {
+  printf '  %-9s %s\n' "$1" "$(basename "$2")"
+  printf '            %s  %s\n' "$(shasum -a 256 "$2" | cut -c1-16)" "$(dirname "$2")"
+}
 
 echo
-echo "Flash plan:"
-echo "  role:    $ROLE ($NRF_FAMILY)"
-echo "  app hex: $HEX_APP"
-[[ -n "$HEX_NET" ]] && echo "  net hex: $HEX_NET"
-echo "  targets: ${TO_FLASH[*]}"
+if [[ "$ERASE" -eq 1 ]]; then
+  echo "Erase plan:"
+  echo "  role:     $ROLE ($NRF_FAMILY)"
+  echo "  action:   full chip erase$([[ "$MULTICORE" -eq 1 ]] && echo ' on BOTH cores'), no programming"
+  echo "  targets:  ${TO_FLASH[*]}"
+else
+  echo "Flash plan:"
+  echo "  role:     $ROLE ($NRF_FAMILY)"
+  hex_line "app hex:" "$HEX_APP"
+  [[ -n "$HEX_NET" ]] && hex_line "net hex:" "$HEX_NET"
+  echo "  targets:  ${TO_FLASH[*]}"
+fi
 echo
 
 # Run a command, or just print it under --dry-run.
@@ -234,6 +295,7 @@ recover_target() {
 }
 
 FLASHED=0
+ERASED=0
 SKIPPED=0
 for snr in "${TO_FLASH[@]}"; do
   fam="$(nrfjprog --snr "$snr" --deviceversion 2>/dev/null || echo 'UNKNOWN')"
@@ -246,9 +308,11 @@ for snr in "${TO_FLASH[@]}"; do
     continue
   fi
 
-  # Decide whether to recover.
+  # Decide whether to recover. --erase-only is exactly "recover and stop".
   recover_this=0
-  if [[ "$NO_RECOVER" -eq 1 ]]; then
+  if [[ "$ERASE" -eq 1 ]]; then
+    recover_this=1
+  elif [[ "$NO_RECOVER" -eq 1 ]]; then
     recover_this=0
     [[ "$fam" == UNKNOWN ]] && echo "WARN $snr: locked (APPROTECT?) and --no-recover given; flashing will likely fail."
   elif [[ "$RECOVER" -eq 1 ]]; then
@@ -277,6 +341,11 @@ for snr in "${TO_FLASH[@]}"; do
     continue
   fi
 
+  if [[ "$ERASE" -eq 1 ]]; then
+    ERASED=$((ERASED + 1))
+    continue
+  fi
+
   echo "Flashing $snr ($fam) as $ROLE ..."
   if [[ "$MULTICORE" -eq 1 ]]; then
     # App core first, then net core - mirrors dotbot device's gateway flow.
@@ -289,4 +358,8 @@ for snr in "${TO_FLASH[@]}"; do
 done
 
 echo
-echo "Done. flashed=$FLASHED skipped=$SKIPPED"
+if [[ "$ERASE" -eq 1 ]]; then
+  echo "Done. erased=$ERASED skipped=$SKIPPED"
+else
+  echo "Done. flashed=$FLASHED skipped=$SKIPPED"
+fi

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -223,7 +223,7 @@ def main(
         on_event,
         serial_interface=SerialAdapter(port),
         mqtt_interface=(
-            MQTTAdapter.from_url(mqtt_host, is_edge=True, *mqtt_credentials()) if mqtt_host else None
+            MQTTAdapter.from_url(mqtt_host, is_edge=True, **mqtt_credentials()) if mqtt_host else None
         ),
         logger=logger,
         main_file=__file__,
@@ -234,47 +234,27 @@ def main(
         metrics_probe_period=metrics_probe_interval or 10.0,
     )
 
-    if metrics_probe_interval is None:
-        # Wait for the schedule, then fix the cadence for the rest of the run.
-        # No probes go out meanwhile: the tester skips every cycle while the
-        # node list is empty, and nodes cannot join before the gateway is up.
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
-            metrics_probe_interval = probe_interval_for_share(mari, probe_load)
-            if metrics_probe_interval is not None:
-                break
-            mari.update()
-            time.sleep(0.2)
-        if metrics_probe_interval is None:
-            sys.stderr.write(
-                "Error: gateway did not report a known schedule within 10 s, so the "
-                "probe interval could not be derived. Pass -i explicitly.\n"
-            )
-            return
-        mari.metrics_tester.set_interval(metrics_probe_interval)
-        if metrics_probe_interval is not None:
-            test_state.probe_load = probe_load
-        print(
-            f"[yellow]Probe interval {metrics_probe_interval:.2f} s "
-            f"= {probe_load:.0f}% of downlink on the "
-            f"{mari.gateway.info.schedule_name} schedule.[/]"
-        )
-
     # Record the knobs that define the scenario, so a run folder is
     # self-describing and does not depend on how its directory was named.
+    # metrics_probe_interval_s is filled in once the cadence is known.
     mari.setup_params.update(
         {
             "load_percent": load,
             "probe_load_percent": probe_load,
-            "metrics_probe_interval_s": round(metrics_probe_interval, 3),
             "send_periodic_s": send_periodic,
         }
     )
+    if metrics_probe_interval is not None:
+        mari.setup_params["metrics_probe_interval_s"] = round(metrics_probe_interval, 3)
+        test_state.probe_interval = metrics_probe_interval
+        test_state.probe_load = 0.0  # an explicit -i is not a share
     logger.log_setup_parameters(mari.setup_params)
 
     stop_event = threading.Event()
 
-    load_tester = LoadTester(mari, test_state, stop_event, probe_interval=metrics_probe_interval)
+    load_tester = LoadTester(
+        mari, test_state, stop_event, probe_interval=metrics_probe_interval or 0.0
+    )
     if load > 0:
         load_tester.start()
 
@@ -287,6 +267,23 @@ def main(
             current_time = time.monotonic()
 
             mari.update()
+
+            # Derive the probe cadence from the gateway's schedule the moment it
+            # is known. Done here rather than by blocking at startup: GATEWAY_INFO
+            # arrives asynchronously over serial and can take longer than any
+            # deadline worth failing a run over. Until then the tester runs at the
+            # placeholder rate, which costs nothing - it skips every cycle while no
+            # node has joined, and a node cannot join a gateway that has not
+            # beaconed its schedule.
+            if metrics_probe_interval is None:
+                derived = probe_interval_for_share(mari, probe_load)
+                if derived is not None:
+                    metrics_probe_interval = derived
+                    mari.metrics_tester.set_interval(derived)
+                    load_tester.probe_interval = derived
+                    test_state.probe_interval = derived
+                    mari.setup_params["metrics_probe_interval_s"] = round(derived, 3)
+                    logger.log_setup_parameters(mari.setup_params)
 
             mari.render_tui()
 

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -13,26 +13,28 @@ from marilib.cli.edge import mqtt_credentials
 from marilib.communication_adapter import SerialAdapter, MQTTAdapter
 
 
-def probe_interval_for_share(mari: MarilibEdge, share_percent: float) -> float | None:
-    """Probe interval (s) that keeps the probe stream at `share_percent` of
-    downlink capacity, for a fully populated schedule.
+def probe_interval_for_slotframes(mari: MarilibEdge, every: int) -> float | None:
+    """Seconds between probes to a node, for one probe every `every` slotframes.
 
-    Derived from the schedule rather than the live node count, so the cadence
-    is fixed for the whole run: a rate that drifted while nodes joined would
-    make latency samples from early and late in a window incomparable. The
-    campaign runs each schedule at capacity, so max_nodes is the right N.
+    The slotframe is the network's own clock - latency, queue depth and the
+    probe timeout are all measured in it - so a cadence expressed in slotframes
+    samples every schedule at the same rate relative to its own dynamics, which
+    is what makes latency comparable across them.
 
-        interval = max_nodes / (share * downlink_capacity)
+    It also holds the probe's share of downlink nearly constant without being
+    asked to. That share is N / (every * d_down), and N/d_down is 5.00, 4.40,
+    4.13, 4.64 for tiny, medium, big and huge - the schedules give each node an
+    uplink slot and scale downlink alongside, so the ratio barely moves. The
+    share is therefore about 4.6/every on any of them: ~23% at every=20, ~15%
+    at 30. Below about 15 the probe stream starts crowding out the traffic it
+    is supposed to be measuring.
 
-    At 15%: tiny 1.0 s, medium 3.4, big 4.8, huge 7.9. Returns None until the
-    gateway has reported its schedule.
+    Returns None until the gateway has reported a schedule we know.
     """
     schedule = SCHEDULES.get(mari.gateway.info.schedule_id)
-    max_rate = mari.get_max_downlink_rate()
-    if schedule is None or max_rate == 0 or share_percent <= 0:
+    if schedule is None or every <= 0:
         return None
-    probes_per_second = max_rate * (share_percent / 100.0)
-    return schedule["max_nodes"] / probes_per_second
+    return every * float(schedule["sf_duration"]) / 1000.0
 
 
 class LoadTester(threading.Thread):
@@ -172,25 +174,24 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
     "--metrics-probe-interval",
     "-i",
     type=float,
-    default=5.0,
-    show_default=True,
+    default=None,
     help=(
-        "Seconds between probes to the same node (max 10). This is the "
-        "sampling requirement: it fixes how often every node's latency and "
-        "PDR are measured, and --load fills the rest of the downlink around "
-        "it. The resulting probe share of capacity is reported in the TUI and "
-        "in the run's metrics_setup.csv."
+        "Seconds between probes to the same node, overriding --probe-every. "
+        "Wall-clock rather than slotframes: use it to reproduce a fixed "
+        "cadence across schedules, e.g. -i 1 for the 2025 campaign's setting."
     ),
 )
 @click.option(
-    "--probe-load",
-    type=float,
-    default=None,
+    "--probe-every",
+    "-k",
+    type=int,
+    default=20,
+    show_default=True,
     help=(
-        "Alternative to -i: cap the probes at this share of downlink capacity "
-        "in percent and let the cadence fall out of the gateway's schedule. "
-        "Holds the measurement footprint constant across schedules, at the "
-        "cost of a sampling rate that varies with node count."
+        "Probe each node once every K slotframes. The slotframe is the "
+        "network's own clock, so one K samples every schedule at the same rate "
+        "relative to its own dynamics and costs a near-constant ~4.6/K of "
+        "downlink capacity on any of them (~23% at K=20). Overridden by -i."
     ),
 )
 @click.option(
@@ -205,21 +206,17 @@ def main(
     mqtt_host: str,
     load: int,
     send_periodic: float,
-    metrics_probe_interval: float,
-    probe_load: float | None,
+    probe_every: int,
+    metrics_probe_interval: float | None,
     log_dir: str,
 ):
     if not (0 <= load <= 100):
         sys.stderr.write("Error: --load must be between 0 and 100.\n")
         return
 
-    # -i is the default knob; --probe-load overrides it by deriving the cadence
-    # from the schedule instead. The two answer different questions: a fixed
-    # interval fixes the sampling rate, a fixed share fixes the footprint.
-    if probe_load is not None:
-        metrics_probe_interval = None
-
-    test_state = TestState(load=load)
+    # -k is the default knob, in the network's own clock; -i overrides it with
+    # wall-clock seconds. Two knobs for one setting, high level and low.
+    test_state = TestState(load=load, probe_every=0 if metrics_probe_interval else probe_every)
 
     logger = MetricsLogger(log_dir_base=log_dir, rotation_interval_minutes=1440)
 
@@ -244,6 +241,7 @@ def main(
     mari.setup_params.update(
         {
             "load_percent": load,
+            "probe_every_slotframes": probe_every if metrics_probe_interval is None else "",
             "send_periodic_s": send_periodic,
         }
     )
@@ -278,7 +276,7 @@ def main(
             # node has joined, and a node cannot join a gateway that has not
             # beaconed its schedule.
             if metrics_probe_interval is None:
-                derived = probe_interval_for_share(mari, probe_load)
+                derived = probe_interval_for_slotframes(mari, probe_every)
                 if derived is not None:
                     metrics_probe_interval = derived
                     mari.metrics_tester.set_interval(derived)

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -169,27 +169,28 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
     help="Send periodic packet every N seconds (0 = disabled)",
 )
 @click.option(
-    "--probe-load",
-    type=float,
-    default=15.0,
-    show_default=True,
-    help=(
-        "Share of downlink capacity the metrics probes may use, in percent. "
-        "The probe interval is derived from it once the gateway reports its "
-        "schedule, so one number holds the measurement's footprint constant "
-        "across every schedule and node count. Ignored if "
-        "--metrics-probe-interval is given."
-    ),
-)
-@click.option(
     "--metrics-probe-interval",
     "-i",
     type=float,
+    default=5.0,
+    show_default=True,
+    help=(
+        "Seconds between probes to the same node (max 10). This is the "
+        "sampling requirement: it fixes how often every node's latency and "
+        "PDR are measured, and --load fills the rest of the downlink around "
+        "it. The resulting probe share of capacity is reported in the TUI and "
+        "in the run's metrics_setup.csv."
+    ),
+)
+@click.option(
+    "--probe-load",
+    type=float,
     default=None,
     help=(
-        "Seconds between probes to the same node (max 10), overriding "
-        "--probe-load. The low-level knob: use it to reproduce a specific "
-        "cadence, e.g. -i 1 for the 2025 campaign's setting."
+        "Alternative to -i: cap the probes at this share of downlink capacity "
+        "in percent and let the cadence fall out of the gateway's schedule. "
+        "Holds the measurement footprint constant across schedules, at the "
+        "cost of a sampling rate that varies with node count."
     ),
 )
 @click.option(
@@ -204,18 +205,21 @@ def main(
     mqtt_host: str,
     load: int,
     send_periodic: float,
-    probe_load: float,
-    metrics_probe_interval: float | None,
+    metrics_probe_interval: float,
+    probe_load: float | None,
     log_dir: str,
 ):
     if not (0 <= load <= 100):
         sys.stderr.write("Error: --load must be between 0 and 100.\n")
         return
 
-    test_state = TestState(
-        load=load,
-        probe_load=probe_load,
-    )
+    # -i is the default knob; --probe-load overrides it by deriving the cadence
+    # from the schedule instead. The two answer different questions: a fixed
+    # interval fixes the sampling rate, a fixed share fixes the footprint.
+    if probe_load is not None:
+        metrics_probe_interval = None
+
+    test_state = TestState(load=load)
 
     logger = MetricsLogger(log_dir_base=log_dir, rotation_interval_minutes=1440)
 
@@ -240,14 +244,12 @@ def main(
     mari.setup_params.update(
         {
             "load_percent": load,
-            "probe_load_percent": probe_load,
             "send_periodic_s": send_periodic,
         }
     )
     if metrics_probe_interval is not None:
         mari.setup_params["metrics_probe_interval_s"] = round(metrics_probe_interval, 3)
         test_state.probe_interval = metrics_probe_interval
-        test_state.probe_load = 0.0  # an explicit -i is not a share
     logger.log_setup_parameters(mari.setup_params)
 
     stop_event = threading.Event()

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -6,10 +6,32 @@ import click
 from marilib.logger import MetricsLogger
 from marilib.mari_protocol import MARI_BROADCAST_ADDRESS, Frame, DefaultPayload, DefaultPayloadType
 from marilib.marilib_edge import MarilibEdge
-from marilib.model import EdgeEvent, GatewayInfo, MariNode, TestState
+from marilib.model import SCHEDULES, EdgeEvent, GatewayInfo, MariNode, TestState
 from marilib.serial_uart import get_default_port
 from marilib.tui_edge import MarilibTUIEdge
 from marilib.communication_adapter import SerialAdapter, MQTTAdapter
+
+
+def probe_interval_for_share(mari: MarilibEdge, share_percent: float) -> float | None:
+    """Probe interval (s) that keeps the probe stream at `share_percent` of
+    downlink capacity, for a fully populated schedule.
+
+    Derived from the schedule rather than the live node count, so the cadence
+    is fixed for the whole run: a rate that drifted while nodes joined would
+    make latency samples from early and late in a window incomparable. The
+    campaign runs each schedule at capacity, so max_nodes is the right N.
+
+        interval = max_nodes / (share * downlink_capacity)
+
+    At 15%: tiny 1.0 s, medium 3.4, big 4.8, huge 7.9. Returns None until the
+    gateway has reported its schedule.
+    """
+    schedule = SCHEDULES.get(mari.gateway.info.schedule_id)
+    max_rate = mari.get_max_downlink_rate()
+    if schedule is None or max_rate == 0 or share_percent <= 0:
+        return None
+    probes_per_second = max_rate * (share_percent / 100.0)
+    return schedule["max_nodes"] / probes_per_second
 
 
 class LoadTester(threading.Thread):
@@ -146,18 +168,27 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
     help="Send periodic packet every N seconds (0 = disabled)",
 )
 @click.option(
+    "--probe-load",
+    type=float,
+    default=15.0,
+    show_default=True,
+    help=(
+        "Share of downlink capacity the metrics probes may use, in percent. "
+        "The probe interval is derived from it once the gateway reports its "
+        "schedule, so one number holds the measurement's footprint constant "
+        "across every schedule and node count. Ignored if "
+        "--metrics-probe-interval is given."
+    ),
+)
+@click.option(
     "--metrics-probe-interval",
     "-i",
     type=float,
-    default=5.0,
-    show_default=True,
+    default=None,
     help=(
-        "Seconds between probes to the same node (max 10). Probes are unicast "
-        "downlink traffic, so they consume the same D slots as --load: at N "
-        "nodes the probe stream offers N/interval packets/s against the "
-        "schedule's downlink capacity (huge 85.6/s, big 91.9, medium 86.6, "
-        "tiny 68.2). --load subtracts this automatically, but keep the share small "
-        "anyway, or the measurement becomes the load."
+        "Seconds between probes to the same node (max 10), overriding "
+        "--probe-load. The low-level knob: use it to reproduce a specific "
+        "cadence, e.g. -i 1 for the 2025 campaign's setting."
     ),
 )
 @click.option(
@@ -172,7 +203,8 @@ def main(
     mqtt_host: str,
     load: int,
     send_periodic: float,
-    metrics_probe_interval: float,
+    probe_load: float,
+    metrics_probe_interval: float | None,
     log_dir: str,
 ):
     if not (0 <= load <= 100):
@@ -192,15 +224,43 @@ def main(
         logger=logger,
         main_file=__file__,
         tui=MarilibTUIEdge(test_state=test_state),
-        metrics_probe_period=metrics_probe_interval,
+        # Placeholder cadence: the real one is derived below, once the gateway
+        # has reported its schedule. A zero here would leave the tester thread
+        # unstarted, and set_interval cannot start it afterwards.
+        metrics_probe_period=metrics_probe_interval or 10.0,
     )
+
+    if metrics_probe_interval is None:
+        # Wait for the schedule, then fix the cadence for the rest of the run.
+        # No probes go out meanwhile: the tester skips every cycle while the
+        # node list is empty, and nodes cannot join before the gateway is up.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            metrics_probe_interval = probe_interval_for_share(mari, probe_load)
+            if metrics_probe_interval is not None:
+                break
+            mari.update()
+            time.sleep(0.2)
+        if metrics_probe_interval is None:
+            sys.stderr.write(
+                "Error: gateway did not report a known schedule within 10 s, so the "
+                "probe interval could not be derived. Pass -i explicitly.\n"
+            )
+            return
+        mari.metrics_tester.set_interval(metrics_probe_interval)
+        print(
+            f"[yellow]Probe interval {metrics_probe_interval:.2f} s "
+            f"= {probe_load:.0f}% of downlink on the "
+            f"{mari.gateway.info.schedule_name} schedule.[/]"
+        )
 
     # Record the knobs that define the scenario, so a run folder is
     # self-describing and does not depend on how its directory was named.
     mari.setup_params.update(
         {
             "load_percent": load,
-            "metrics_probe_interval_s": metrics_probe_interval,
+            "probe_load_percent": probe_load,
+            "metrics_probe_interval_s": round(metrics_probe_interval, 3),
             "send_periodic_s": send_periodic,
         }
     )

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -213,6 +213,7 @@ def main(
 
     test_state = TestState(
         load=load,
+        probe_load=probe_load,
     )
 
     logger = MetricsLogger(log_dir_base=log_dir, rotation_interval_minutes=1440)
@@ -248,6 +249,8 @@ def main(
             )
             return
         mari.metrics_tester.set_interval(metrics_probe_interval)
+        if metrics_probe_interval is not None:
+            test_state.probe_load = probe_load
         print(
             f"[yellow]Probe interval {metrics_probe_interval:.2f} s "
             f"= {probe_load:.0f}% of downlink on the "

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -224,7 +224,9 @@ def main(
         on_event,
         serial_interface=SerialAdapter(port),
         mqtt_interface=(
-            MQTTAdapter.from_url(mqtt_host, is_edge=True, **mqtt_credentials()) if mqtt_host else None
+            MQTTAdapter.from_url(mqtt_host, is_edge=True, **mqtt_credentials())
+            if mqtt_host
+            else None
         ),
         logger=logger,
         main_file=__file__,

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -9,6 +9,7 @@ from marilib.marilib_edge import MarilibEdge
 from marilib.model import SCHEDULES, EdgeEvent, GatewayInfo, MariNode, TestState
 from marilib.serial_uart import get_default_port
 from marilib.tui_edge import MarilibTUIEdge
+from marilib.cli.edge import mqtt_credentials
 from marilib.communication_adapter import SerialAdapter, MQTTAdapter
 
 
@@ -221,7 +222,9 @@ def main(
     mari = MarilibEdge(
         on_event,
         serial_interface=SerialAdapter(port),
-        mqtt_interface=MQTTAdapter.from_url(mqtt_host, is_edge=True) if mqtt_host else None,
+        mqtt_interface=(
+            MQTTAdapter.from_url(mqtt_host, is_edge=True, *mqtt_credentials()) if mqtt_host else None
+        ),
         logger=logger,
         main_file=__file__,
         tui=MarilibTUIEdge(test_state=test_state),

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -97,13 +97,34 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
     help="Send periodic packet every N seconds (0 = disabled)",
 )
 @click.option(
+    "--metrics-probe-interval",
+    "-i",
+    type=float,
+    default=5.0,
+    show_default=True,
+    help=(
+        "Seconds between probes to the same node (max 10). Probes are unicast "
+        "downlink traffic, so they consume the same D slots as --load: at N "
+        "nodes the probe stream offers N/interval packets/s against the "
+        "schedule's downlink capacity (huge 85.6/s, big 91.9, medium 86.6, "
+        "tiny 68.2). Keep that share small, or the measurement becomes the load."
+    ),
+)
+@click.option(
     "--log-dir",
     default="logs",
     show_default=True,
     help="Directory to save metric log files.",
     type=click.Path(),
 )
-def main(port: str | None, mqtt_host: str, load: int, send_periodic: float, log_dir: str):
+def main(
+    port: str | None,
+    mqtt_host: str,
+    load: int,
+    send_periodic: float,
+    metrics_probe_interval: float,
+    log_dir: str,
+):
     if not (0 <= load <= 100):
         sys.stderr.write("Error: --load must be between 0 and 100.\n")
         return
@@ -121,8 +142,19 @@ def main(port: str | None, mqtt_host: str, load: int, send_periodic: float, log_
         logger=logger,
         main_file=__file__,
         tui=MarilibTUIEdge(test_state=test_state),
-        metrics_probe_period=1.0,  # use a relatively frequent probe period to get more stats
+        metrics_probe_period=metrics_probe_interval,
     )
+
+    # Record the knobs that define the scenario, so a run folder is
+    # self-describing and does not depend on how its directory was named.
+    mari.setup_params.update(
+        {
+            "load_percent": load,
+            "metrics_probe_interval_s": metrics_probe_interval,
+            "send_periodic_s": send_periodic,
+        }
+    )
+    logger.log_setup_parameters(mari.setup_params)
 
     stop_event = threading.Event()
 

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -13,29 +13,40 @@ from marilib.communication_adapter import SerialAdapter, MQTTAdapter
 
 
 class LoadTester(threading.Thread):
+    """Generates filler downlink traffic up to a target link occupancy.
+
+    `--load` is the share of the gateway's downlink capacity the link should
+    carry in total, metrics probes included. Probes are unicast downlink
+    packets competing for the same D slots as the filler, so the filler rate
+    is the target minus the probe rate. Without that subtraction, asking for
+    75% on the huge schedule puts 90% on the link, which measures the knee
+    rather than a loaded network.
+    """
+
     def __init__(
         self,
         mari: MarilibEdge,
         test_state: TestState,
         stop_event: threading.Event,
+        probe_interval: float = 0.0,
     ):
         super().__init__(daemon=True)
         self.mari = mari
         self.test_state = test_state
         self._stop_event = stop_event
-        self.has_rate = False
-        self.delay = None
+        self.probe_interval = probe_interval
+        self._warned_over_budget = False
 
     def run(self):
         while not self._stop_event.is_set():
-            # wait for gateway schedule to be available and try to compute rate
-            if not self.has_rate:
-                self.set_rate()
-            if self.delay is None:
-                self._stop_event.wait(0.1)  # fixed, waiting for gateway schedule to be available
+            delay = self.compute_delay()
+            if delay is None:
+                # Gateway schedule not known yet, or the probe stream already
+                # fills the budget. Re-check shortly: both can change as the
+                # gateway reports in and as nodes join or leave.
+                self._stop_event.wait(0.1)
                 continue
 
-            # once we have rate, send packets at that rate
             with self.mari.lock:
                 nodes_exist = bool(self.mari.gateway.nodes)
 
@@ -44,19 +55,53 @@ class LoadTester(threading.Thread):
                     MARI_BROADCAST_ADDRESS,
                     DefaultPayload(type_=DefaultPayloadType.METRICS_LOAD).with_filler_bytes(180),
                 )
-            self._stop_event.wait(self.delay)
+            self._stop_event.wait(delay)
 
-    def set_rate(self):
+    def probe_rate(self) -> float:
+        """Nominal probe packets/s: one per node per probe interval.
+
+        Nominal, not measured: a probe that times out is retransmitted (up to
+        MAX_PROBE_RETRIES), so under heavy loss the real probe rate is higher
+        and the link carries more than the requested share. That regime is
+        visible in the log as a non-zero pending-probe count and an effective
+        latency pinned at two slotframes.
+        """
+        if self.probe_interval <= 0:
+            return 0.0
+        with self.mari.lock:
+            node_count = len(self.mari.gateway.nodes)
+        return node_count / self.probe_interval
+
+    def compute_delay(self) -> float | None:
+        """Seconds between filler packets, or None if none should be sent.
+
+        Recomputed per packet rather than latched at startup: the probe stream
+        scales with the node count, so a rate fixed during formation would
+        overshoot the target once the network filled up.
+        """
         if self.test_state.load == 0:
-            return
+            return None
         max_rate = self.mari.get_max_downlink_rate()
         if max_rate == 0:
-            sys.stderr.write("Error computing max rate")
-            return
+            return None  # gateway schedule not reported yet
+
         self.test_state.rate = int(max_rate)
-        packets_per_second = max_rate * (self.test_state.load / 100.0)
-        self.delay = 1.0 / packets_per_second if packets_per_second > 0 else float("inf")
-        self.has_rate = True
+        target_pps = max_rate * (self.test_state.load / 100.0)
+        filler_pps = target_pps - self.probe_rate()
+
+        if filler_pps <= 0:
+            if not self._warned_over_budget:
+                self._warned_over_budget = True
+                sys.stderr.write(
+                    f"Warning: metrics probes alone offer "
+                    f"{self.probe_rate() / max_rate:.0%} of downlink capacity, at or above the "
+                    f"requested {self.test_state.load}%. Sending no filler traffic; either raise "
+                    f"--load or raise --metrics-probe-interval.\n"
+                )
+            return None
+
+        self._warned_over_budget = False
+        return 1.0 / filler_pps
 
 
 def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
@@ -86,7 +131,11 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
     type=int,
     default=0,
     show_default=True,
-    help="Load percentage to apply (0–100)",
+    help=(
+        "Target downlink occupancy in percent (0-100), metrics probes INCLUDED. "
+        "The filler rate is this target minus the probe rate, so --load 75 puts 75% "
+        "on the link rather than 75% plus whatever the probes add. 0 disables filler."
+    ),
 )
 @click.option(
     "--send-periodic",
@@ -107,7 +156,8 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
         "downlink traffic, so they consume the same D slots as --load: at N "
         "nodes the probe stream offers N/interval packets/s against the "
         "schedule's downlink capacity (huge 85.6/s, big 91.9, medium 86.6, "
-        "tiny 68.2). Keep that share small, or the measurement becomes the load."
+        "tiny 68.2). --load subtracts this automatically, but keep the share small "
+        "anyway, or the measurement becomes the load."
     ),
 )
 @click.option(
@@ -158,7 +208,7 @@ def main(
 
     stop_event = threading.Event()
 
-    load_tester = LoadTester(mari, test_state, stop_event)
+    load_tester = LoadTester(mari, test_state, stop_event, probe_interval=metrics_probe_interval)
     if load > 0:
         load_tester.start()
 

--- a/marilib/examples/mari_edge_stats.py
+++ b/marilib/examples/mari_edge_stats.py
@@ -275,6 +275,12 @@ def main(
             # placeholder rate, which costs nothing - it skips every cycle while no
             # node has joined, and a node cannot join a gateway that has not
             # beaconed its schedule.
+            # Downlink capacity, for the TUI's probe-share readout. Set here
+            # rather than only in LoadTester: at --load 0 the load tester never
+            # starts, and the probe budget is exactly what you want to see in
+            # that case.
+            test_state.rate = int(mari.get_max_downlink_rate())
+
             if metrics_probe_interval is None:
                 derived = probe_interval_for_slotframes(mari, probe_every)
                 if derived is not None:

--- a/marilib/marilib/cli/cloud.py
+++ b/marilib/marilib/cli/cloud.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import click
@@ -7,6 +8,17 @@ from marilib.model import EdgeEvent, GatewayInfo, MariNode
 from marilib.communication_adapter import MQTTAdapter
 from marilib.tui_cloud import MarilibTUICloud
 from marilib.logger import MetricsLogger
+
+
+def mqtt_credentials() -> tuple[str | None, str | None]:
+    """MQTT username and password from the environment.
+
+    Same variable names as the `dotbot` CLI, so one export serves both.
+    Keeping credentials out of the URL keeps them out of shell history and
+    out of any command a run sheet reproduces; MQTTAdapter.from_url still
+    accepts the `mqtts://user:pass@host` form when that is easier.
+    """
+    return os.environ.get("DOTBOT_MQTT_USER"), os.environ.get("DOTBOT_MQTT_PASS")
 
 
 def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
@@ -58,7 +70,7 @@ def main(mqtt_url: str, network_id: int, send_periodic: float, log_dir: str, max
 
     mari = MarilibCloud(
         on_event,
-        mqtt_interface=MQTTAdapter.from_url(mqtt_url, is_edge=False),
+        mqtt_interface=MQTTAdapter.from_url(mqtt_url, is_edge=False, *mqtt_credentials()),
         logger=MetricsLogger(
             log_dir_base=log_dir, rotation_interval_minutes=1440, log_interval_seconds=1.0
         ),

--- a/marilib/marilib/cli/cloud.py
+++ b/marilib/marilib/cli/cloud.py
@@ -10,15 +10,19 @@ from marilib.tui_cloud import MarilibTUICloud
 from marilib.logger import MetricsLogger
 
 
-def mqtt_credentials() -> tuple[str | None, str | None]:
-    """MQTT username and password from the environment.
+def mqtt_credentials() -> dict[str, str | None]:
+    """MQTT username and password from the environment, as kwargs.
 
     Same variable names as the `dotbot` CLI, so one export serves both.
-    Keeping credentials out of the URL keeps them out of shell history and
-    out of any command a run sheet reproduces; MQTTAdapter.from_url still
-    accepts the `mqtts://user:pass@host` form when that is easier.
+    Returned as a dict for `**` splatting: positional unpacking collides with
+    `is_edge` at every call site. Keeping credentials out of the URL keeps
+    them out of shell history and out of any command a run sheet reproduces;
+    MQTTAdapter.from_url still accepts the `mqtts://user:pass@host` form.
     """
-    return os.environ.get("DOTBOT_MQTT_USER"), os.environ.get("DOTBOT_MQTT_PASS")
+    return {
+        "username": os.environ.get("DOTBOT_MQTT_USER"),
+        "password": os.environ.get("DOTBOT_MQTT_PASS"),
+    }
 
 
 def on_event(event: EdgeEvent, event_data: MariNode | Frame | GatewayInfo):
@@ -70,7 +74,7 @@ def main(mqtt_url: str, network_id: int, send_periodic: float, log_dir: str, max
 
     mari = MarilibCloud(
         on_event,
-        mqtt_interface=MQTTAdapter.from_url(mqtt_url, is_edge=False, *mqtt_credentials()),
+        mqtt_interface=MQTTAdapter.from_url(mqtt_url, is_edge=False, **mqtt_credentials()),
         logger=MetricsLogger(
             log_dir_base=log_dir, rotation_interval_minutes=1440, log_interval_seconds=1.0
         ),

--- a/marilib/marilib/cli/edge.py
+++ b/marilib/marilib/cli/edge.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import click
@@ -8,6 +9,17 @@ from marilib.communication_adapter import SerialAdapter, MQTTAdapter
 from marilib.serial_uart import get_default_port
 from marilib.tui_edge import MarilibTUIEdge
 from marilib.marilib_edge import MarilibEdge
+
+
+def mqtt_credentials() -> tuple[str | None, str | None]:
+    """MQTT username and password from the environment.
+
+    Same variable names as the `dotbot` CLI, so one export serves both.
+    Keeping credentials out of the URL keeps them out of shell history and
+    out of any command a run sheet reproduces; MQTTAdapter.from_url still
+    accepts the `mqtts://user:pass@host` form when that is easier.
+    """
+    return os.environ.get("DOTBOT_MQTT_USER"), os.environ.get("DOTBOT_MQTT_PASS")
 
 
 def on_event(event: EdgeEvent, event_data: MariNode | Frame):
@@ -55,7 +67,11 @@ def main(port: str | None, mqtt_url: str, metrics_probe_interval: float, log_dir
     mari = MarilibEdge(
         on_event,
         serial_interface=SerialAdapter(port),
-        mqtt_interface=MQTTAdapter.from_url(mqtt_url, is_edge=True) if mqtt_url else None,
+        mqtt_interface=(
+            MQTTAdapter.from_url(mqtt_url, is_edge=True, *mqtt_credentials())
+            if mqtt_url
+            else None
+        ),
         logger=logger,
         tui=MarilibTUIEdge(),
         main_file=__file__,

--- a/marilib/marilib/cli/edge.py
+++ b/marilib/marilib/cli/edge.py
@@ -48,17 +48,25 @@ def on_event(event: EdgeEvent, event_data: MariNode | Frame):
 def main(port: str | None, mqtt_url: str, metrics_probe_interval: float, log_dir: str):
     """A basic example of using the MarilibEdge library."""
 
+    logger = MetricsLogger(
+        log_dir_base=log_dir, rotation_interval_minutes=1440, log_interval_seconds=1.0
+    )
+
     mari = MarilibEdge(
         on_event,
         serial_interface=SerialAdapter(port),
         mqtt_interface=MQTTAdapter.from_url(mqtt_url, is_edge=True) if mqtt_url else None,
-        logger=MetricsLogger(
-            log_dir_base=log_dir, rotation_interval_minutes=1440, log_interval_seconds=1.0
-        ),
+        logger=logger,
         tui=MarilibTUIEdge(),
         main_file=__file__,
         metrics_probe_period=metrics_probe_interval,  # use a less frequent probe to interfere less with the main traffic
     )
+
+    # Same as mari_edge_stats.py: keep the run folder self-describing, so a
+    # measurement is identifiable from its own data rather than its directory
+    # name. No load_percent here - this CLI has no load generator.
+    mari.setup_params["metrics_probe_interval_s"] = metrics_probe_interval
+    logger.log_setup_parameters(mari.setup_params)
 
     try:
         while True:

--- a/marilib/marilib/cli/edge.py
+++ b/marilib/marilib/cli/edge.py
@@ -72,9 +72,7 @@ def main(port: str | None, mqtt_url: str, metrics_probe_interval: float, log_dir
         on_event,
         serial_interface=SerialAdapter(port),
         mqtt_interface=(
-            MQTTAdapter.from_url(mqtt_url, is_edge=True, **mqtt_credentials())
-            if mqtt_url
-            else None
+            MQTTAdapter.from_url(mqtt_url, is_edge=True, **mqtt_credentials()) if mqtt_url else None
         ),
         logger=logger,
         tui=MarilibTUIEdge(),

--- a/marilib/marilib/cli/edge.py
+++ b/marilib/marilib/cli/edge.py
@@ -11,15 +11,19 @@ from marilib.tui_edge import MarilibTUIEdge
 from marilib.marilib_edge import MarilibEdge
 
 
-def mqtt_credentials() -> tuple[str | None, str | None]:
-    """MQTT username and password from the environment.
+def mqtt_credentials() -> dict[str, str | None]:
+    """MQTT username and password from the environment, as kwargs.
 
     Same variable names as the `dotbot` CLI, so one export serves both.
-    Keeping credentials out of the URL keeps them out of shell history and
-    out of any command a run sheet reproduces; MQTTAdapter.from_url still
-    accepts the `mqtts://user:pass@host` form when that is easier.
+    Returned as a dict for `**` splatting: positional unpacking collides with
+    `is_edge` at every call site. Keeping credentials out of the URL keeps
+    them out of shell history and out of any command a run sheet reproduces;
+    MQTTAdapter.from_url still accepts the `mqtts://user:pass@host` form.
     """
-    return os.environ.get("DOTBOT_MQTT_USER"), os.environ.get("DOTBOT_MQTT_PASS")
+    return {
+        "username": os.environ.get("DOTBOT_MQTT_USER"),
+        "password": os.environ.get("DOTBOT_MQTT_PASS"),
+    }
 
 
 def on_event(event: EdgeEvent, event_data: MariNode | Frame):
@@ -68,7 +72,7 @@ def main(port: str | None, mqtt_url: str, metrics_probe_interval: float, log_dir
         on_event,
         serial_interface=SerialAdapter(port),
         mqtt_interface=(
-            MQTTAdapter.from_url(mqtt_url, is_edge=True, *mqtt_credentials())
+            MQTTAdapter.from_url(mqtt_url, is_edge=True, **mqtt_credentials())
             if mqtt_url
             else None
         ),

--- a/marilib/marilib/logger.py
+++ b/marilib/marilib/logger.py
@@ -239,32 +239,35 @@ class MetricsLogger:
 
         timestamp = datetime.now().isoformat()
         for node in nodes:
-            row = [
-                timestamp,
-                f"0x{node.gateway_address:016X}",
-                f"0x{node.address:016X}",
-                node.is_alive,
-                # node.stats.sent_count(include_test_packets=False),
-                # node.stats.received_count(include_test_packets=False),
-                # node.stats.sent_count(1, include_test_packets=False),
-                # node.stats.received_count(1, include_test_packets=False),
-                f"{node.stats.success_rate(30):.2%}",
-                f"{node.stats.success_rate():.2%}",
-                f"{node.pdr_downlink:.2%}",
-                f"{node.pdr_uplink:.2%}",
-                f"{self._safe_fraction(node.stats_pdr_downlink_radio()):.2%}",
-                f"{self._safe_fraction(node.stats_pdr_uplink_radio()):.2%}",
-                f"{self._safe_fraction(node.stats_pdr_downlink_uart()):.2%}",
-                f"{self._safe_fraction(node.stats_pdr_uplink_uart()):.2%}",
-                node.stats_rssi_node_dbm(),
-                node.stats_rssi_gw_dbm(),
-                f"{node.stats_avg_latency_roundtrip_node_edge_ms():.2f}",
-                f"{node.stats_avg_effective_latency_ms():.2f}",
-                node.stats_pending_probe_count(),
-                f"{node.stats_avg_latency_roundtrip_node_edge_ms():.2f}",  # FIXME!: should use cloud option
-                f"{node.stats_latest_latency_roundtrip_node_edge_ms():.2f}",
-                f"{node.stats_latest_latency_roundtrip_node_edge_ms():.2f}",  # FIXME!: should use cloud option
-            ] + self._latest_probe_fields(node)
+            row = (
+                [
+                    timestamp,
+                    f"0x{node.gateway_address:016X}",
+                    f"0x{node.address:016X}",
+                    node.is_alive,
+                    # node.stats.sent_count(include_test_packets=False),
+                    # node.stats.received_count(include_test_packets=False),
+                    # node.stats.sent_count(1, include_test_packets=False),
+                    # node.stats.received_count(1, include_test_packets=False),
+                    f"{node.stats.success_rate(30):.2%}",
+                    f"{node.stats.success_rate():.2%}",
+                    f"{node.pdr_downlink:.2%}",
+                    f"{node.pdr_uplink:.2%}",
+                    f"{self._safe_fraction(node.stats_pdr_downlink_radio()):.2%}",
+                    f"{self._safe_fraction(node.stats_pdr_uplink_radio()):.2%}",
+                    f"{self._safe_fraction(node.stats_pdr_downlink_uart()):.2%}",
+                    f"{self._safe_fraction(node.stats_pdr_uplink_uart()):.2%}",
+                    node.stats_rssi_node_dbm(),
+                    node.stats_rssi_gw_dbm(),
+                    f"{node.stats_avg_latency_roundtrip_node_edge_ms():.2f}",
+                    f"{node.stats_avg_effective_latency_ms():.2f}",
+                    node.stats_pending_probe_count(),
+                    f"{node.stats_avg_latency_roundtrip_node_edge_ms():.2f}",  # FIXME!: should use cloud option
+                    f"{node.stats_latest_latency_roundtrip_node_edge_ms():.2f}",
+                    f"{node.stats_latest_latency_roundtrip_node_edge_ms():.2f}",  # FIXME!: should use cloud option
+                ]
+                + self._latest_probe_fields(node)
+            )
             self._nodes_writer.writerow(row)
 
     def log_event(

--- a/marilib/marilib/logger.py
+++ b/marilib/marilib/logger.py
@@ -15,7 +15,6 @@ class MetricsLogger:
 
     log_dir_base: str = "logs"
     rotation_interval_minutes: int = 1440  # 1 day
-    already_logged_setup_parameters: bool = False
     log_interval_seconds: float = 1.0
     last_log_time: Dict[int, datetime] = field(default_factory=dict)
 
@@ -55,11 +54,15 @@ class MetricsLogger:
             self.active = False
 
     def log_setup_parameters(self, params: Dict[str, any] | None):
-        """Creates and writes test setup parameters to metrics_setup.csv."""
-        if not params or self.already_logged_setup_parameters:
+        """Creates and writes test setup parameters to metrics_setup.csv.
+
+        Rewrites the file on every call. Callers enrich the parameter dict as
+        facts arrive - the schedule name is only knowable once the first
+        GATEWAY_INFO lands, well after the logger is constructed - and a
+        write-once guard here silently dropped every one of those late fields.
+        """
+        if not params:
             return
-        # only log setup parameters once
-        self.already_logged_setup_parameters = True
 
         setup_path = os.path.join(self.log_dir, "metrics_setup.csv")
         with open(setup_path, "w", newline="", encoding="utf-8") as f:
@@ -128,6 +131,22 @@ class MetricsLogger:
             "avg_latency_cloud_ms",
             "last_latency_edge_ms",
             "last_latency_cloud_ms",
+            # Raw counters and ASN split from the node's latest probe, one
+            # sample per probe rather than a rolling average. Rows are written
+            # every log_interval_seconds, so consecutive rows repeat the same
+            # probe until a new one lands: dedup on edge_rx_count. The six
+            # counters make PDR exact over any window (and per node), which
+            # the rolling radio_pdr_* columns above cannot give.
+            "gw_tx_count",
+            "gw_rx_count",
+            "node_tx_count",
+            "node_rx_count",
+            "edge_tx_count",
+            "edge_rx_count",
+            "last_downlink_half_ms",
+            "last_node_processing_ms",
+            "last_uplink_half_ms",
+            "last_wire_rtt_ms",
         ]
         self._nodes_writer.writerow(nodes_header)
 
@@ -184,6 +203,28 @@ class MetricsLogger:
             return 0.0
         return 0.0 if v < 0 else min(v, 1.0)
 
+    def _latest_probe_fields(self, node: MariNode) -> list:
+        """Raw counters + ASN-decomposed latency from the node's latest probe.
+
+        Blank (not 0) when the node has no probe yet, so "no sample" stays
+        distinguishable from a genuine zero counter.
+        """
+        probe = node.probe_stats_latest
+        if probe is None:
+            return [""] * 10
+        return [
+            probe.gw_tx_count,
+            probe.gw_rx_count,
+            probe.node_tx_count,
+            probe.node_rx_count,
+            probe.edge_tx_count,
+            probe.edge_rx_count,
+            f"{probe.downlink_half_ms():.2f}",
+            f"{probe.node_processing_ms():.2f}",
+            f"{probe.uplink_half_ms():.2f}",
+            f"{probe.wire_rtt_ms():.2f}",
+        ]
+
     def log_all_nodes_metrics(self, nodes: List[MariNode]):
         """Writes metrics for all nodes, handling rotation."""
         if not self._log_common() or self._nodes_writer is None:
@@ -216,7 +257,7 @@ class MetricsLogger:
                 f"{node.stats_avg_latency_roundtrip_node_edge_ms():.2f}",  # FIXME!: should use cloud option
                 f"{node.stats_latest_latency_roundtrip_node_edge_ms():.2f}",
                 f"{node.stats_latest_latency_roundtrip_node_edge_ms():.2f}",  # FIXME!: should use cloud option
-            ]
+            ] + self._latest_probe_fields(node)
             self._nodes_writer.writerow(row)
 
     def log_event(

--- a/marilib/marilib/logger.py
+++ b/marilib/marilib/logger.py
@@ -166,6 +166,13 @@ class MetricsLogger:
             self.log_gateway_metrics(gateway)
             self.log_all_nodes_metrics(nodes)
             self.last_log_time[gateway.info.address] = datetime.now()
+            # Flush at the sampling rate, as log_events.csv already does. Two
+            # reasons: a run becomes readable while it is still going, and a
+            # process that dies without running close() still leaves its data
+            # behind instead of an empty file.
+            for f in (self._gateway_file, self._nodes_file):
+                if f and not f.closed:
+                    f.flush()
 
     def log_gateway_metrics(self, gateway: MariGateway):
         if not self._log_common() or self._gateway_writer is None:

--- a/marilib/marilib/metrics.py
+++ b/marilib/marilib/metrics.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from collections import deque
 from typing import TYPE_CHECKING
 
 from rich import print
@@ -63,6 +64,12 @@ class MetricsTester:
         self.set_interval(interval)
         self._stop_event = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
+        # Monotonic timestamps of recent probe transmissions, for the measured
+        # send rate. Retries are counted, which is the point: the nominal rate
+        # (nodes / interval) understates the link's real probe load whenever
+        # probes are timing out. deque append/popleft are thread-safe, so the
+        # TUI can read this while the tester thread writes.
+        self._sent_ts: deque[float] = deque(maxlen=4096)
 
     def set_interval(self, interval: float):
         if interval < 0 or interval > MARI_PROBE_STATS_MAX_LEN:
@@ -153,9 +160,22 @@ class MetricsTester:
         edge_tx_ts_us = self.marilib.send_probe(node.address, payload_bytes)
         if edge_tx_ts_us is None:
             return None
+        self._sent_ts.append(time.monotonic())
         with self.marilib.lock:
             self._register_pending_probe(node, edge_tx_ts_us, edge_tx_ts_us, retry_count)
         return edge_tx_ts_us
+
+    def probe_rate_hz(self, window_s: float = 10.0) -> float:
+        """Measured probe transmissions per second over the last `window_s`.
+
+        Measured rather than nominal, so retries after a timeout show up. A
+        reading well above nodes/interval means probes are being retransmitted,
+        which puts more on the downlink than the requested probe share.
+        """
+        now = time.monotonic()
+        while self._sent_ts and now - self._sent_ts[0] > window_s:
+            self._sent_ts.popleft()
+        return len(self._sent_ts) / window_s
 
     def _send_edge_probe(self, node: MariNode) -> None:
         """Send a probe if the node has no pending one."""

--- a/marilib/marilib/metrics.py
+++ b/marilib/marilib/metrics.py
@@ -244,13 +244,24 @@ class MetricsTester:
             return
 
         rx_ts = rx_ts_us if rx_ts_us is not None else self.timestamp_us()
-        pending = self._complete_pending_probe(node, payload.edge_tx_ts_us, rx_ts)
-        if pending is None:
-            # Stale reply (e.g. after timeout/retry): skip probe_stats — RTT would be bogus.
-            return None
 
+        # Stamp before matching. A reply that arrives after its timeout has no
+        # pending entry left, but it did arrive, so edge_rx_ts_us and
+        # edge_rx_count are both known and both belong on the wire: the frame
+        # is forwarded to the cloud right after this returns, and an unstamped
+        # edge_rx_ts_us of 0 makes latency_roundtrip_node_edge_ms() read as a
+        # large negative value there. Counting every reply in edge_rx_count
+        # also makes pdr_uplink_uart (edge_rx vs gw_rx) count what it names.
         payload.edge_rx_ts_us = rx_ts
         payload.edge_rx_count = node.probe_increment_rx_count()
+
+        pending = self._complete_pending_probe(node, payload.edge_tx_ts_us, rx_ts)
+        if pending is None:
+            # Late reply: check_timeouts already recorded this probe as a
+            # timeout in the effective-latency samples, so keep it out of
+            # probe_stats rather than counting one probe twice. Returned
+            # stamped so the cloud still sees its true round trip.
+            return payload
 
         node.save_probe_stats(payload)
 

--- a/marilib/marilib/metrics.py
+++ b/marilib/marilib/metrics.py
@@ -11,7 +11,7 @@ from marilib.mari_protocol import (
     Header,
     MetricsProbePayload,
 )
-from marilib.model import MARI_PROBE_STATS_MAX_LEN, MariGateway, MariNode, SCHEDULES
+from marilib.model import MariGateway, MariNode, SCHEDULES
 from marilib.probe_tracker import MAX_PROBE_RETRIES, PendingProbe
 
 if TYPE_CHECKING:
@@ -72,14 +72,27 @@ class MetricsTester:
         self._sent_ts: deque[float] = deque(maxlen=4096)
 
     def set_interval(self, interval: float):
-        if interval < 0 or interval > MARI_PROBE_STATS_MAX_LEN:
-            raise ValueError(f"Interval must be >= 0 and <= {MARI_PROBE_STATS_MAX_LEN}")
+        """Set the seconds between probes to the same node. 0 disables probing.
+
+        Only non-negative is enforced. There is no upper bound to enforce: a
+        long interval simply samples sparsely and widens the rolling PDR
+        window, since MARI_PROBE_STATS_MAX_LEN caps how many probe payloads are
+        retained per node, not how far apart they may be. (It was previously
+        used as a seconds ceiling, comparing a duration against a deque
+        length.)
+
+        The bound that would be worth having is at the other end - an interval
+        short enough that N/interval exceeds the gateway's downlink capacity -
+        but that depends on the schedule and the node count, neither of which
+        is known here or fixed for the run. It is reported instead: the TUI
+        shows the probe stream's live share of downlink.
+        """
+        if interval < 0:
+            raise ValueError(f"Probe interval must be >= 0, got {interval}")
         self.interval = interval
 
     def start(self):
         """Starts the metrics testing thread."""
-        if self.interval < 0 or self.interval > MARI_PROBE_STATS_MAX_LEN:
-            raise ValueError(f"Interval must be >= 0 and <= {MARI_PROBE_STATS_MAX_LEN}")
         if self.interval == 0:
             print("[yellow]Metrics tester disabled.[/]")
             return

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -328,34 +328,32 @@ class MariNode:
         return self.probe_stats_latest.rssi_at_gw_dbm()
 
     def stats_avg_latency_roundtrip_node_edge_ms(self) -> float:
-        """Average latency between node and edge in milliseconds"""
-        # compute average latency between node and edge, using all probe stats
+        """Average latency between node and edge in milliseconds.
+
+        Non-positive samples are skipped: a probe whose edge_rx_ts_us was
+        never stamped reads as a large negative round trip and would swamp
+        the mean."""
         if not self.probe_stats:
             return 0
-        return sum(p.latency_roundtrip_node_edge_ms() for p in self.probe_stats) / len(
-            self.probe_stats
-        )
+        return self._avg_nonzero([p.latency_roundtrip_node_edge_ms() for p in self.probe_stats])
 
     def stats_avg_latency_roundtrip_node_cloud_ms(self) -> float:
         """Average latency between node and cloud in milliseconds"""
         if not self.probe_stats:
             return 0
-        return sum(p.latency_roundtrip_node_cloud_ms() for p in self.probe_stats) / len(
-            self.probe_stats
-        )
+        return self._avg_nonzero([p.latency_roundtrip_node_cloud_ms() for p in self.probe_stats])
 
     def stats_latest_latency_roundtrip_node_edge_ms(self) -> float:
         """Last latency between node and edge in milliseconds"""
-        # compute average latency between node and edge, using all probe stats
         if not self.probe_stats:
             return 0
-        return self.probe_stats_latest.latency_roundtrip_node_edge_ms()
+        return max(0.0, self.probe_stats_latest.latency_roundtrip_node_edge_ms())
 
     def stats_latest_latency_roundtrip_node_cloud_ms(self) -> float:
         """Last latency between node and cloud in milliseconds"""
         if not self.probe_stats:
             return 0
-        return self.probe_stats_latest.latency_roundtrip_node_cloud_ms()
+        return max(0.0, self.probe_stats_latest.latency_roundtrip_node_cloud_ms())
 
     # ASN-decomposed latency aggregates. Each averages over the
     # probe_stats deque, ignoring samples where the relevant ASN pair

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -66,6 +66,7 @@ class TestState:
     rate: int = 0
     load: int = 0
     probe_interval: float = 0.0  # seconds between probes to the same node
+    probe_every: int = 0  # that cadence in slotframes, 0 when set directly in seconds
 
 
 class EdgeEvent(IntEnum):

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -65,8 +65,7 @@ MARI_PROBE_STATS_MAX_LEN = 10
 class TestState:
     rate: int = 0
     load: int = 0
-    probe_load: float = 0.0  # target probe share of downlink capacity, percent
-    probe_interval: float = 0.0  # cadence derived from that share, seconds
+    probe_interval: float = 0.0  # seconds between probes to the same node
 
 
 class EdgeEvent(IntEnum):

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -65,6 +65,7 @@ MARI_PROBE_STATS_MAX_LEN = 10
 class TestState:
     rate: int = 0
     load: int = 0
+    probe_load: float = 0.0  # target probe share of downlink capacity, percent
 
 
 class EdgeEvent(IntEnum):

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -66,6 +66,7 @@ class TestState:
     rate: int = 0
     load: int = 0
     probe_load: float = 0.0  # target probe share of downlink capacity, percent
+    probe_interval: float = 0.0  # cadence derived from that share, seconds
 
 
 class EdgeEvent(IntEnum):

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -227,21 +227,20 @@ class MarilibTUIEdge(MarilibTUI):
             status.append(f"{self.test_state.load}% of {self.test_state.rate} pps")
             status.append("  |  ")
 
-        # Probe budget vs what the probes are actually sending. The measured
-        # rate counts retries, so it runs above target when probes are timing
-        # out - which is the case where the link is carrying more than the
-        # requested load and the latency series is being censored.
-        if self.test_state and self.test_state.probe_load > 0 and self.test_state.rate > 0:
+        # The probe cadence, and the share of downlink it actually costs. The
+        # measured rate counts retries, so it runs above the nominal
+        # nodes/interval exactly when probes are timing out - the case where the
+        # link carries more than was asked for and the latency series is being
+        # censored.
+        if self.test_state and self.test_state.probe_interval > 0 and self.test_state.rate > 0:
             measured = mari.metrics_tester.probe_rate_hz() if mari.metrics_tester else 0.0
-            measured_pct = 100.0 * measured / self.test_state.rate
-            over = measured_pct > self.test_state.probe_load * 1.25
+            nominal = len(mari.gateway.nodes) / self.test_state.probe_interval
+            over = nominal > 0 and measured > nominal * 1.25
             status.append("Probe: ")
-            status.append(
-                f"{self.test_state.probe_load:.0f}% @ {self.test_state.probe_interval:.1f}s",
-            )
+            status.append(f"{self.test_state.probe_interval:.1f}s")
             status.append(" / ")
             status.append(
-                f"{measured:.1f} pps = {measured_pct:.0f}%",
+                f"{measured:.1f} pps = {100.0 * measured / self.test_state.rate:.0f}% of downlink",
                 style="yellow" if over else "",
             )
             if over:

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -252,6 +252,28 @@ class MarilibTUIEdge(MarilibTUI):
                 status.append(" (retrying)", style="yellow")
             status.append("  |  ")
 
+        # Uplink pressure. Each node owns exactly one uplink slot per slotframe
+        # (the C schedules carry max_nodes U cells), so its budget is
+        # 1/sf_duration packets per second and the interesting number is what
+        # fraction of it the node is actually using. Measured from the frames
+        # the edge received rather than derived from the node app's send rates:
+        # the 500 ms status packet alone is 51% of the budget on the huge
+        # schedule, and that is a firmware constant this side should not assume.
+        schedule = SCHEDULES.get(mari.gateway.info.schedule_id)
+        node_count = len(mari.gateway.nodes)
+        if schedule and node_count and schedule["sf_duration"]:
+            window = 10
+            up_pps = mari.gateway.stats.received_count(window, include_test_packets=True) / window
+            per_node = up_pps / node_count
+            budget = 1000.0 / float(schedule["sf_duration"])
+            used = per_node / budget
+            status.append("Uplink: ")
+            status.append(
+                f"{up_pps:.1f} pps, {per_node:.2f}/node = {used:.0%} of slot budget",
+                style="red" if used > 0.95 else ("yellow" if used > 0.8 else ""),
+            )
+            status.append("  |  ")
+
         stats = mari.gateway.stats
         status.append(f"Frames TX: {stats.sent_count(include_test_packets=True)}  |  ")
         status.append(f"Frames RX: {stats.received_count(include_test_packets=True)}  |  ")

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -237,7 +237,12 @@ class MarilibTUIEdge(MarilibTUI):
             nominal = len(mari.gateway.nodes) / self.test_state.probe_interval
             over = nominal > 0 and measured > nominal * 1.25
             status.append("Probe: ")
-            status.append(f"{self.test_state.probe_interval:.1f}s")
+            if self.test_state.probe_every:
+                status.append(
+                    f"{self.test_state.probe_every} sf = {self.test_state.probe_interval:.1f}s"
+                )
+            else:
+                status.append(f"{self.test_state.probe_interval:.1f}s")
             status.append(" / ")
             status.append(
                 f"{measured:.1f} pps = {100.0 * measured / self.test_state.rate:.0f}% of downlink",

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -237,7 +237,7 @@ class MarilibTUIEdge(MarilibTUI):
             over = measured_pct > self.test_state.probe_load * 1.25
             status.append("Probe: ")
             status.append(
-                f"{self.test_state.probe_load:.0f}% target",
+                f"{self.test_state.probe_load:.0f}% @ {self.test_state.probe_interval:.1f}s",
             )
             status.append(" / ")
             status.append(

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -22,6 +22,26 @@ if TYPE_CHECKING:
 QUEUE_DEPTH_WARN_SF = 2.0
 QUEUE_DEPTH_BAD_SF = 4.0
 
+# Per-node RSSI (dBm) thresholds for coloring the link-quality value.
+# RSSI is negative; more negative = weaker. At or below BAD we color the
+# value red (poor link), between WARN and BAD yellow, above WARN plain.
+RSSI_WARN_DBM = -60  # weaker than this -> yellow
+RSSI_BAD_DBM = -70  # weaker than this -> red
+
+
+def _rssi_cell(dbm: "float | None") -> str:
+    """Format an RSSI value (dBm) with color: red for weak links
+    (<= RSSI_BAD_DBM), yellow for marginal (<= RSSI_WARN_DBM), plain
+    otherwise. Returns '...' when no sample is available."""
+    if dbm is None:
+        return "..."
+    val = f"{dbm:.0f}"
+    if dbm <= RSSI_BAD_DBM:
+        return f"[red]{val}[/red]"
+    if dbm <= RSSI_WARN_DBM:
+        return f"[yellow]{val}[/yellow]"
+    return val
+
 
 class MarilibTUIEdge(MarilibTUI):
     """A Text-based User Interface for MarilibEdge."""
@@ -207,6 +227,27 @@ class MarilibTUIEdge(MarilibTUI):
             status.append(f"{self.test_state.load}% of {self.test_state.rate} pps")
             status.append("  |  ")
 
+        # Probe budget vs what the probes are actually sending. The measured
+        # rate counts retries, so it runs above target when probes are timing
+        # out - which is the case where the link is carrying more than the
+        # requested load and the latency series is being censored.
+        if self.test_state and self.test_state.probe_load > 0 and self.test_state.rate > 0:
+            measured = mari.metrics_tester.probe_rate_hz() if mari.metrics_tester else 0.0
+            measured_pct = 100.0 * measured / self.test_state.rate
+            over = measured_pct > self.test_state.probe_load * 1.25
+            status.append("Probe: ")
+            status.append(
+                f"{self.test_state.probe_load:.0f}% target",
+            )
+            status.append(" / ")
+            status.append(
+                f"{measured:.1f} pps = {measured_pct:.0f}%",
+                style="yellow" if over else "",
+            )
+            if over:
+                status.append(" (retrying)", style="yellow")
+            status.append("  |  ")
+
         stats = mari.gateway.stats
         status.append(f"Frames TX: {stats.sent_count(include_test_packets=True)}  |  ")
         status.append(f"Frames RX: {stats.received_count(include_test_packets=True)}  |  ")
@@ -345,14 +386,8 @@ class MarilibTUIEdge(MarilibTUI):
             else:
                 pdr_up_gw_edge_str = "..."
 
-            rssi_node_str = (
-                f"{node.stats_rssi_node_dbm():.0f}"
-                if node.stats_rssi_node_dbm() is not None
-                else "..."
-            )
-            rssi_gw_str = (
-                f"{node.stats_rssi_gw_dbm():.0f}" if node.stats_rssi_gw_dbm() is not None else "..."
-            )
+            rssi_node_str = _rssi_cell(node.stats_rssi_node_dbm())
+            rssi_gw_str = _rssi_cell(node.stats_rssi_gw_dbm())
 
             table.add_row(
                 f"0x{node.address:016X}",

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -252,26 +252,39 @@ class MarilibTUIEdge(MarilibTUI):
                 status.append(" (retrying)", style="yellow")
             status.append("  |  ")
 
-        # Uplink pressure. Each node owns exactly one uplink slot per slotframe
-        # (the C schedules carry max_nodes U cells), so its budget is
-        # 1/sf_duration packets per second and the interesting number is what
-        # fraction of it the node is actually using. Measured from the frames
-        # the edge received rather than derived from the node app's send rates:
-        # the 500 ms status packet alone is 51% of the budget on the huge
-        # schedule, and that is a firmware constant this side should not assume.
+        # Raw link saturation, both directions, from frames actually counted -
+        # independent of what --load or --probe-every were set to. The settings
+        # say what was asked for; this says what the link is carrying.
+        #
+        # Downlink capacity is d_down slots per slotframe. Uplink capacity is
+        # one slot per *connected* node per slotframe (the C schedules carry
+        # exactly max_nodes U cells), so the denominator follows the node count:
+        # unassigned U slots are idle by construction and including them would
+        # hide node-level saturation behind an empty schedule.
         schedule = SCHEDULES.get(mari.gateway.info.schedule_id)
         node_count = len(mari.gateway.nodes)
-        if schedule and node_count and schedule["sf_duration"]:
+        if schedule and schedule["sf_duration"]:
             window = 10
-            up_pps = mari.gateway.stats.received_count(window, include_test_packets=True) / window
-            per_node = up_pps / node_count
-            budget = 1000.0 / float(schedule["sf_duration"])
-            used = per_node / budget
-            status.append("Uplink: ")
-            status.append(
-                f"{up_pps:.1f} pps, {per_node:.2f}/node = {used:.0%} of slot budget",
-                style="red" if used > 0.95 else ("yellow" if used > 0.8 else ""),
-            )
+            sf_s = float(schedule["sf_duration"]) / 1000.0
+            dl_pps = mari.gateway.stats.sent_count(window) / window
+            ul_pps = mari.gateway.stats.received_count(window) / window
+            dl_cap = float(schedule["d_down"]) / sf_s
+            ul_cap = node_count / sf_s if node_count else 0.0
+
+            def _sat(pps, cap):
+                if cap <= 0:
+                    return "n/a", ""
+                frac = pps / cap
+                style = "red" if frac > 0.95 else ("yellow" if frac > 0.8 else "")
+                return f"{pps:.1f}/{cap:.1f} = {frac:.0%}", style
+
+            dl_txt, dl_style = _sat(dl_pps, dl_cap)
+            ul_txt, ul_style = _sat(ul_pps, ul_cap)
+            status.append("Link: ")
+            status.append("DL ")
+            status.append(dl_txt, style=dl_style)
+            status.append("  UL ")
+            status.append(ul_txt, style=ul_style)
             status.append("  |  ")
 
         stats = mari.gateway.stats

--- a/marilib/tests/test_probe_tracker.py
+++ b/marilib/tests/test_probe_tracker.py
@@ -64,6 +64,9 @@ def test_matching_response_records_effective_and_rtt():
 
 
 def test_unmatched_response_ignored_for_rtt_stats():
+    """An unmatched (late) reply stays out of the edge's own RTT stats, but is
+    still stamped and returned so the frame forwarded to the cloud carries a
+    usable edge_rx_ts_us instead of 0."""
     tester, marilib = _make_tester()
     node = _add_test_node(marilib)
 
@@ -73,7 +76,9 @@ def test_unmatched_response_ignored_for_rtt_stats():
     )
     payload = tester.handle_response_edge(frame, rx_ts_us=60000)
 
-    assert payload is None
+    assert payload is not None
+    assert payload.edge_rx_ts_us == 60000
+    assert payload.latency_roundtrip_node_edge_ms() == pytest.approx(50.001)
     assert node.stats_avg_effective_latency_ms() == 0.0
     assert len(node.probe_stats) == 0
 


### PR DESCRIPTION
Preparing marilib to measure latency and PDR for a measurement campaign turned
up several things that made the numbers wrong or unreadable rather than merely
inconvenient. This fixes them and adds the firmware tooling the campaign needs.

## The probe stream had to stop scaling with the fleet

The probe interval was per node, so the offered probe load grew linearly with
the node count: a fixed 5 s/node is 20 probes/s at 100 nodes but 2 at 10. That
makes the instrument itself the variable under test when the fleet size or the
schedule changes.

`--probe-every` now cadences in **slotframes** instead of seconds, so the probe
share of downlink stays roughly constant across schedules (N/(K x d_down) is
within a few percent of 4.6/K for tiny through huge). `-i` still sets a
wall-clock interval when that is what you want. The cadence is derived lazily,
once the gateway has actually reported its schedule, because deriving it up
front meant a fixed deadline that could abort a run before the first beacon.

`--load` now means **total** downlink occupancy: the load generator subtracts
the measured probe rate, so passing 75 puts 75% on the link rather than 75%
plus whatever the probes were already using. Recomputed per packet, since the
probe stream grows with the node count.

Also removes an upper bound in `set_interval` that compared a value in seconds
against a deque length, and so silently clamped long intervals.

## Late probe replies were being discarded after being counted

The edge stamped `edge_rx_ts_us` only after matching a reply against the
pending-probe table, so a reply arriving after its entry had been evicted was
dropped without a timestamp - censoring exactly the slow tail that a latency
distribution is about. Stamping happens before the match now, so a late reply
still reaches the cloud carrying usable data.

## A gateway leaked a metrics slot on every repeated join

`metrics_add_node` took a fresh slot every time it was called, without checking
whether the node was already tracked. A gateway that sees more joins than
leaves therefore leaked a slot per unmatched join until the 149-entry table
filled, after which the function silently did nothing: a node that rejoined was
never re-added, so its `tx_count` and `rx_count` stopped incrementing while the
gateway kept serving it.

This is the one change here that is not measurement-side. It was found on a
two-gateway run where the gateway with a balanced 191/189 join/leave count
reported sane PDR, while the one at 277/182 needed 188 slots, overflowed, and
left 25 of 107 nodes with a frozen `tx_count` - which reads as the gateway
having stopped transmitting to nodes it was still serving, and pushed downlink
PDR above 100% so the run had to be discarded. Adding each node only once keeps
the same run at 93 of 149 slots. A full table is now reported rather than
passed over, because past that point every metric the gateway emits for a newly
joined node is wrong and nothing downstream can tell.

## The logs could not reconstruct a run

`node_metrics.csv` gained the raw counters (`gw_tx_count`, `gw_rx_count`,
`node_tx_count`, `node_rx_count`, `edge_tx_count`, `edge_rx_count`) and the
per-hop latency halves, so PDR can be computed after the fact from counter
deltas rather than trusted from a running average. This matters because a node
rejoining zeroes the gateway's counters but not its own, and only the raw pairs
let an analysis segment around that.

`metrics_setup.csv` records the run's parameters, the write-once guard on it is
gone (it prevented recording a cadence derived after startup), and the metrics
CSVs are flushed at the sampling rate so a run can be analysed while it is still
going.

## TUI and CLI

The TUI shows the probe budget as a share of downlink, the measured probe rate
with a retry indicator, uplink slot utilisation, and raw link saturation in both
directions - enough to see a saturating link during a run instead of at the
analysis. MQTT credentials now come from the environment.

## Firmware tooling

`flash.sh` lists only the role's own device family and reports other-family
boards separately, so a missing board is distinguishable from one plugged in
under the wrong role. The guard runs before any recover, so flashing nodes
cannot wipe a gateway. It also gains `--erase-only`, a `both` role that runs the
gateway pass then the node pass with the same options, and `--net-id`, which
provisions the gateway's network id into its config page after programming so
one image is usable on any network.

`build-schedules.sh` builds one gateway net-core image per schedule. The
schedule is a compile-time pointer, so switching it means a rebuild, and since
building takes minutes while flashing takes seconds the images are built once
and flashed from a cache by name (`flash.sh --schedule tiny`). `--schedule`
refuses an image older than the firmware sources, since a stale image is
otherwise indistinguishable from a fresh one; `--build` refreshes just that one.
The script edits a single line to select the schedule and restores the file
byte-for-byte on exit, including through a failure, because a bench tree
legitimately carries local edits that must survive the build.

Both scripts are documented in `firmware/AGENTS.md`, and the user-facing half in
the README.

## Validation

The Python changes have run continuously on the bench: 100 nodes at 2 m and
10 m, four traffic loads, and a schedule sweep across tiny/medium/big/huge, with
the counters cross-checked against the sliding-window PDR marilib reports
independently. The instrument has since carried the campaigns it was built for,
at roughly 200 nodes across one and two gateways, on the huge schedule, at
downlink loads from 0 to 75%, in five-minute windows.

`hatch fmt --check` and `hatch test` pass. The firmware change to
`03app_gateway_net/metrics.c` is compiled code and has been exercised on the
bench; the rest of the firmware diff is scripts.