### PR TITLE
models: mark schedule_t backoff fields as unused

### DIFF
--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -210,8 +210,8 @@ typedef struct {
 typedef struct {
     uint8_t id;                       // unique identifier for the schedule
     uint8_t max_nodes;                // maximum number of nodes that can be scheduled, equivalent to the number of uplink slot_durations
-    uint8_t backoff_n_min;            // minimum exponent for the backoff algorithm
-    uint8_t backoff_n_max;            // maximum exponent for the backoff algorithm
+    uint8_t backoff_n_min;            // unused; the MAC uses MARI_BACKOFF_N_MIN in association.c
+    uint8_t backoff_n_max;            // unused; the MAC uses MARI_BACKOFF_N_MAX in association.c
     size_t  n_cells;                  // number of cells in this schedule
     cell_t  cells[MARI_N_CELLS_MAX];  // cells in this schedule. NOTE(FIXME?): the first 3 cells must be beacons
 } schedule_t;


### PR DESCRIPTION
The backoff_n_min / backoff_n_max fields set in every schedule definition (all_schedules.c, test_schedules.c) are never read by the MAC: the contention backoff exponents come from MARI_BACKOFF_N_MIN and MARI_BACKOFF_N_MAX in association.c. Anyone tuning join contention by editing a schedule's fields silently changes nothing.

This marks the two fields as unused at their declaration in models.h and points to where the real constants live. Comment-only change, no behavior touched.