### PR TITLE
gateway: count uart and inter-core losses end to end (superseded by #172)

### DIFF
--- a/firmware/app/03app_gateway_app/ipc.h
+++ b/firmware/app/03app_gateway_app/ipc.h
@@ -17,6 +17,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "models.h"
+
 #if defined(NRF_APPLICATION)
 #define NRF_MUTEX NRF_MUTEX_NS
 #elif defined(NRF_NETWORK)
@@ -31,11 +33,14 @@ typedef enum {
 } ipc_channels_t;
 
 typedef struct __attribute__((packed)) {
-    bool    net_ready;                 ///< Network core is ready
-    uint8_t radio_to_uart[UINT8_MAX];  ///< Data received from the network core
-    uint8_t radio_to_uart_len;         ///< Length of the data received from the network core
-    uint8_t uart_to_radio[UINT8_MAX];  ///< Data to send to the network
-    uint8_t uart_to_radio_len;         ///< Length of the data to send to the network core
+    bool                    net_ready;                 ///< Network core is ready
+    uint8_t                 radio_to_uart[UINT8_MAX];  ///< Data received from the network core
+    uint8_t                 radio_to_uart_len;         ///< Length of the data received from the network core
+    uint8_t                 radio_to_uart_seq;         ///< Bumped by the net core on every radio_to_uart write
+    uint8_t                 uart_to_radio[UINT8_MAX];  ///< Data to send to the network
+    uint8_t                 uart_to_radio_len;         ///< Length of the data to send to the network core
+    uint8_t                 uart_to_radio_seq;         ///< Bumped by the app core on every uart_to_radio write
+    mr_gateway_uart_stats_t stats;                     ///< Counters reported to the host in gateway_info
 } ipc_shared_data_t;
 
 /**

--- a/firmware/app/03app_gateway_app/main.c
+++ b/firmware/app/03app_gateway_app/main.c
@@ -46,6 +46,15 @@ typedef struct {
     uint8_t    tx_queue_head;
     uint8_t    tx_queue_tail;
     uint8_t    tx_queue_count;
+
+    // counters this core owns, mirrored into shared RAM for the net core to
+    // put in gateway_info
+    uint32_t rx_frames_ok;
+    uint32_t rx_hdlc_err;
+    uint32_t rx_slot_full;
+    uint32_t tx_queue_drop;
+    uint32_t ipc_r2u_lost;
+    uint8_t  ipc_r2u_seq;  ///< last radio_to_uart sequence number this core consumed
 } gateway_app_vars_t;
 
 // UART RX and TX pins
@@ -149,9 +158,31 @@ static void _uart_callback(uint8_t *buffer, size_t length) {
         return;
     }
 
+    if (_app_vars.uart_buffer_received) {
+        // the main loop has not drained the previous chunk yet; it is about to
+        // be overwritten and its bytes never reach the HDLC decoder
+        _app_vars.rx_slot_full++;
+    }
     memcpy(_app_vars.uart_buffer, buffer, length);
     _app_vars.uart_buffer_length   = length;
     _app_vars.uart_buffer_received = true;
+}
+
+// Copy this core's counters into shared RAM. The net core reads them there
+// when it builds gateway_info, so they only need to be as fresh as the
+// slotframe that carries them.
+static void _publish_stats(void) {
+    const mr_uart_rx_stats_t *uart_stats = mr_uart_rx_stats(MR_UART_INDEX);
+
+    ipc_shared_data.stats.uart_rx_bytes      = uart_stats->rx_bytes;
+    ipc_shared_data.stats.uart_rx_hw_overrun = uart_stats->hw_overrun;
+    ipc_shared_data.stats.uart_rx_hw_framing = uart_stats->hw_framing;
+    ipc_shared_data.stats.uart_rx_hw_break   = uart_stats->hw_break;
+    ipc_shared_data.stats.uart_rx_frames_ok  = _app_vars.rx_frames_ok;
+    ipc_shared_data.stats.uart_rx_hdlc_err   = _app_vars.rx_hdlc_err;
+    ipc_shared_data.stats.uart_rx_slot_full  = _app_vars.rx_slot_full;
+    ipc_shared_data.stats.uart_tx_queue_drop = _app_vars.tx_queue_drop;
+    ipc_shared_data.stats.ipc_r2u_lost       = _app_vars.ipc_r2u_lost;
 }
 
 int main(void) {
@@ -173,6 +204,8 @@ int main(void) {
     while (1) {
         __WFE();
 
+        _publish_stats();
+
         if (_app_vars.uart_buffer_received) {
             _app_vars.uart_buffer_received = false;
 
@@ -185,11 +218,14 @@ int main(void) {
                     size_t msg_len                    = mr_hdlc_decode((uint8_t *)(void *)ipc_shared_data.uart_to_radio);
                     ipc_shared_data.uart_to_radio_len = msg_len;
                     if (msg_len) {
+                        _app_vars.rx_frames_ok++;
+                        ipc_shared_data.uart_to_radio_seq++;
                         NRF_IPC_S->TASKS_SEND[IPC_CHAN_UART_TO_RADIO] = 1;
                     }
                     // we can break since we assume that the python code never sends two frames too fast in a row
                     break;
                 } else if (hdlc_state == MR_HDLC_STATE_ERROR) {
+                    _app_vars.rx_hdlc_err++;
                     break;
                 }
             }
@@ -222,9 +258,16 @@ void IPC_IRQHandler(void) {
     if (NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_RADIO_TO_UART]) {
         NRF_IPC_S->EVENTS_RECEIVE[IPC_CHAN_RADIO_TO_UART] = 0;
 
+        // This handler is the consumer of radio_to_uart, so a jump of more
+        // than one in the producer's sequence number counts the messages the
+        // net core wrote over before they were read.
+        uint8_t seq = ipc_shared_data.radio_to_uart_seq;
+        _app_vars.ipc_r2u_lost += (uint8_t)(seq - _app_vars.ipc_r2u_seq) - 1;
+        _app_vars.ipc_r2u_seq = seq;
+
         // Enqueue the frame instead of just setting a flag
         if (!_tx_queue_enqueue((const uint8_t *)ipc_shared_data.radio_to_uart, ipc_shared_data.radio_to_uart_len)) {
-            // Queue full - could add error handling/statistics here
+            _app_vars.tx_queue_drop++;
         }
     }
 }

--- a/firmware/app/03app_gateway_app/uart.c
+++ b/firmware/app/03app_gateway_app/uart.c
@@ -52,15 +52,16 @@ typedef struct {
 } uart_conf_t;
 
 typedef struct {
-    uint8_t         rx_trigger_byte_ptr;    ///< pointer to the byte that triggers the RX state machine
-    uint8_t         rx_trigger_byte_saved;  ///< saved value of the byte that triggered the RX state machine (because the ptr tends to get overwritten)
-    uint8_t         rx_buffer[256];         ///< the buffer where received bytes on UART are stored
-    uart_rx_cb_t    callback;               ///< pointer to the callback function
-    uint8_t        *tx_buffer;              ///< current TX buffer
-    size_t          tx_length;              ///< total bytes to transmit
-    size_t          tx_pos;                 ///< current position in TX buffer
-    bool            tx_busy;                ///< flag indicating TX is in progress
-    uart_rx_state_t rx_state;               ///< current state of the RX state machine
+    uint8_t            rx_trigger_byte_ptr;    ///< pointer to the byte that triggers the RX state machine
+    uint8_t            rx_trigger_byte_saved;  ///< saved value of the byte that triggered the RX state machine (because the ptr tends to get overwritten)
+    uint8_t            rx_buffer[256];         ///< the buffer where received bytes on UART are stored
+    uart_rx_cb_t       callback;               ///< pointer to the callback function
+    uint8_t           *tx_buffer;              ///< current TX buffer
+    size_t             tx_length;              ///< total bytes to transmit
+    size_t             tx_pos;                 ///< current position in TX buffer
+    bool               tx_busy;                ///< flag indicating TX is in progress
+    uart_rx_state_t    rx_state;               ///< current state of the RX state machine
+    mr_uart_rx_stats_t rx_stats;               ///< cumulative RX counters
 } uart_vars_t;
 
 //=========================== variables ========================================
@@ -212,8 +213,12 @@ void mr_uart_init(uart_t uart, const mr_gpio_t *rx_pin, const mr_gpio_t *tx_pin,
 
         _uart_vars[uart].callback = callback;
 
-        // setup the RX interrupt
-        _devs[uart].p->INTENSET = (UARTE_INTENSET_ENDRX_Enabled << UARTE_INTENSET_ENDRX_Pos);
+        // setup the RX interrupt. ERROR is enabled so that a byte the internal
+        // RX FIFO had to drop shows up as ERRORSRC.OVERRUN instead of being
+        // invisible.
+        _devs[uart].p->ERRORSRC = _devs[uart].p->ERRORSRC;
+        _devs[uart].p->INTENSET = (UARTE_INTENSET_ENDRX_Enabled << UARTE_INTENSET_ENDRX_Pos) |
+                                  (UARTE_INTENSET_ERROR_Enabled << UARTE_INTENSET_ERROR_Pos);
 
         // setup the RX state machine and start receiving
         mr_uart_start_rx(uart, UART_RX_STATE_RX_TRIGGER_BYTE);
@@ -259,6 +264,10 @@ bool mr_uart_tx_busy(uart_t uart) {
     return _uart_vars[uart].tx_busy;
 }
 
+const mr_uart_rx_stats_t *mr_uart_rx_stats(uart_t uart) {
+    return &_uart_vars[uart].rx_stats;
+}
+
 void mr_uart_start_rx(uart_t uart, uart_rx_state_t state) {
     _uart_vars[uart].rx_state = state;
     if (state == UART_RX_STATE_RX_TRIGGER_BYTE) {
@@ -278,9 +287,28 @@ void mr_uart_start_rx(uart_t uart, uart_rx_state_t state) {
 extern mr_gpio_t pin_dbg_uart, pin_dbg_timer;
 static void      _uart_isr(uart_t uart) {
 
+    // a byte was lost or corrupted on the wire; ERRORSRC latches the cause
+    if (_devs[uart].p->EVENTS_ERROR) {
+        _devs[uart].p->EVENTS_ERROR = 0;
+        uint32_t errorsrc           = _devs[uart].p->ERRORSRC;
+        _devs[uart].p->ERRORSRC     = errorsrc;  // write-one-to-clear
+        if (errorsrc & (UARTE_ERRORSRC_OVERRUN_Present << UARTE_ERRORSRC_OVERRUN_Pos)) {
+            _uart_vars[uart].rx_stats.hw_overrun++;
+        }
+        if (errorsrc & (UARTE_ERRORSRC_FRAMING_Present << UARTE_ERRORSRC_FRAMING_Pos)) {
+            _uart_vars[uart].rx_stats.hw_framing++;
+        }
+        if (errorsrc & (UARTE_ERRORSRC_BREAK_Present << UARTE_ERRORSRC_BREAK_Pos)) {
+            _uart_vars[uart].rx_stats.hw_break++;
+        }
+        // ERRORSRC.PARITY has no counter: CONFIG leaves parity excluded, so the
+        // bit cannot be set.
+    }
+
     // check if the interrupt was caused by a fully received package
     if (_devs[uart].p->EVENTS_ENDRX) {
         _devs[uart].p->EVENTS_ENDRX = 0;
+        _uart_vars[uart].rx_stats.rx_bytes += _devs[uart].p->RXD.AMOUNT;
         // make sure we actually received new data
         if (_devs[uart].p->RXD.AMOUNT != 0) {
             if (_uart_vars[uart].rx_state == UART_RX_STATE_RX_TRIGGER_BYTE && _devs[uart].p->RXD.AMOUNT == 1) {

--- a/firmware/app/03app_gateway_app/uart.h
+++ b/firmware/app/03app_gateway_app/uart.h
@@ -26,6 +26,14 @@ typedef uint8_t uart_t;  ///< UART peripheral index
 // typedef void (*uart_rx_cb_t)(uint8_t data);  ///< Callback function prototype, it is called on each byte received
 typedef void (*uart_rx_cb_t)(uint8_t *buffer, size_t length);  ///< Callback function prototype, it is called on each byte received
 
+/// Cumulative RX counters owned by this driver, reset only on reboot
+typedef struct {
+    uint32_t rx_bytes;    ///< Bytes the UARTE moved from the wire into RAM
+    uint32_t hw_overrun;  ///< ERRORSRC.OVERRUN: the internal RX FIFO dropped a byte
+    uint32_t hw_framing;  ///< ERRORSRC.FRAMING
+    uint32_t hw_break;    ///< ERRORSRC.BREAK
+} mr_uart_rx_stats_t;
+
 //=========================== public ===========================================
 
 /**
@@ -56,5 +64,14 @@ void mr_uart_write(uart_t uart, uint8_t *buffer, size_t length);
  * @return true if TX is in progress, false otherwise
  */
 bool mr_uart_tx_busy(uart_t uart);
+
+/**
+ * @brief   Read the driver's cumulative RX counters
+ *
+ * @param[in]   uart        UART interface to read
+ *
+ * @return pointer to the counters, owned by the driver and updated from the ISR
+ */
+const mr_uart_rx_stats_t *mr_uart_rx_stats(uart_t uart);
 
 #endif

--- a/firmware/app/03app_gateway_net/ipc.h
+++ b/firmware/app/03app_gateway_net/ipc.h
@@ -17,6 +17,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "models.h"
+
 #if defined(NRF_APPLICATION)
 #define NRF_MUTEX NRF_MUTEX_NS
 #elif defined(NRF_NETWORK)
@@ -31,11 +33,14 @@ typedef enum {
 } ipc_channels_t;
 
 typedef struct __attribute__((packed)) {
-    bool    net_ready;                    ///< Network core is ready
-    uint8_t radio_to_uart[UINT8_MAX];     ///< Data received from the network core
-    uint8_t radio_to_uart_len;            ///< Length of the data received from the network core
-    uint8_t uart_to_radio_tx[UINT8_MAX];  ///< Data to send to the network
-    uint8_t uart_to_radio_len;            ///< Length of the data to send to the network core
+    bool                    net_ready;                    ///< Network core is ready
+    uint8_t                 radio_to_uart[UINT8_MAX];     ///< Data received from the network core
+    uint8_t                 radio_to_uart_len;            ///< Length of the data received from the network core
+    uint8_t                 radio_to_uart_seq;            ///< Bumped by the net core on every radio_to_uart write
+    uint8_t                 uart_to_radio_tx[UINT8_MAX];  ///< Data to send to the network
+    uint8_t                 uart_to_radio_len;            ///< Length of the data to send to the network core
+    uint8_t                 uart_to_radio_seq;            ///< Bumped by the app core on every uart_to_radio write
+    mr_gateway_uart_stats_t stats;                        ///< Counters reported to the host in gateway_info
 } ipc_shared_data_t;
 
 /**

--- a/firmware/app/03app_gateway_net/main.c
+++ b/firmware/app/03app_gateway_net/main.c
@@ -43,6 +43,7 @@ typedef struct {
     bool            to_uart_gateway_loop_ready;
     uint32_t        tx_count;
     uint32_t        rx_count;
+    uint8_t         ipc_u2r_seq;  ///< last uart_to_radio sequence number this core consumed
 } gateway_vars_t;
 
 typedef struct __attribute__((packed)) {
@@ -158,13 +159,23 @@ int main(void) {
             }
 
             if (send_to_uart) {
+                ipc_shared_data.radio_to_uart_seq++;
                 NRF_IPC_NS->TASKS_SEND[IPC_CHAN_RADIO_TO_UART] = 1;
             }
         }
 
         if (_app_vars.uart_to_radio_packet_ready) {
             _app_vars.uart_to_radio_packet_ready = false;
-            uint8_t packet_type                  = ipc_shared_data.uart_to_radio_tx[0];
+
+            // This loop, not the IPC handler, is the consumer of
+            // uart_to_radio_tx, so the gap has to be measured here: two IPC
+            // signals arriving between two passes leave a single buffer
+            // holding only the second message.
+            uint8_t seq                        = ipc_shared_data.uart_to_radio_seq;
+            ipc_shared_data.stats.ipc_u2r_lost += (uint8_t)(seq - _app_vars.ipc_u2r_seq) - 1;
+            _app_vars.ipc_u2r_seq              = seq;
+
+            uint8_t packet_type = ipc_shared_data.uart_to_radio_tx[0];
             if (packet_type != MARI_EDGE_DATA) {
                 printf("Invalid UART packet type: %02X\n", packet_type);
                 continue;
@@ -188,10 +199,13 @@ int main(void) {
         }
 
         if (_app_vars.to_uart_gateway_loop_ready) {
-            _app_vars.to_uart_gateway_loop_ready           = false;
-            ipc_shared_data.radio_to_uart[0]               = MARI_EDGE_GATEWAY_INFO;
-            size_t len                                     = mr_build_uart_packet_gateway_info((uint8_t *)(ipc_shared_data.radio_to_uart + 1));
-            ipc_shared_data.radio_to_uart_len              = 1 + len;
+            _app_vars.to_uart_gateway_loop_ready = false;
+            ipc_shared_data.radio_to_uart[0]     = MARI_EDGE_GATEWAY_INFO;
+            size_t len                           = mr_build_uart_packet_gateway_info(
+                (uint8_t *)(ipc_shared_data.radio_to_uart + 1),
+                (const mr_gateway_uart_stats_t *)&ipc_shared_data.stats);
+            ipc_shared_data.radio_to_uart_len = 1 + len;
+            ipc_shared_data.radio_to_uart_seq++;
             NRF_IPC_NS->TASKS_SEND[IPC_CHAN_RADIO_TO_UART] = 1;
         }
 

--- a/firmware/mari/models.h
+++ b/firmware/mari/models.h
@@ -237,14 +237,34 @@ typedef enum {
     MARI_EDGE_GATEWAY_INFO = 5,
 } mr_gateway_edge_type_t;
 
+// Cumulative gateway-side counters for the host UART link and for the two
+// inter-core mailboxes. They only reset on reboot, so a host reads rates by
+// differencing consecutive gateway_info packets. Every field is owned by
+// exactly one core: the app core owns all of them except ipc_u2r_lost, which
+// only the net core is in a position to observe.
+typedef struct __attribute__((packed)) {
+    uint32_t uart_rx_bytes;       ///< Bytes the UARTE moved from the wire into RAM
+    uint32_t uart_rx_frames_ok;   ///< HDLC frames that passed the FCS check
+    uint32_t uart_rx_hdlc_err;    ///< HDLC frames the decoder rejected
+    uint32_t uart_rx_hw_overrun;  ///< ERRORSRC.OVERRUN: the internal RX FIFO dropped a byte
+    uint32_t uart_rx_hw_framing;  ///< ERRORSRC.FRAMING
+    uint32_t uart_rx_hw_break;    ///< ERRORSRC.BREAK
+    uint32_t uart_rx_slot_full;   ///< Received bytes discarded because no RX buffer was free
+    uint32_t uart_tx_queue_drop;  ///< Uplink frames dropped because the TX queue was full
+    uint32_t ipc_u2r_lost;        ///< Downlink messages lost between the app and the net core
+    uint32_t ipc_r2u_lost;        ///< Uplink messages lost between the net and the app core
+} mr_gateway_uart_stats_t;
+
 // uart packet for gateway info
 typedef struct __attribute__((packed)) {
-    uint64_t device_id;
-    uint16_t net_id;
-    uint16_t schedule_id;
-    uint64_t sched_usage[MARI_STATS_SCHED_USAGE_SIZE];
-    uint64_t asn;
-    uint32_t timer;
+    uint8_t                 version;
+    uint64_t                device_id;
+    uint16_t                net_id;
+    uint16_t                schedule_id;
+    uint64_t                sched_usage[MARI_STATS_SCHED_USAGE_SIZE];
+    uint64_t                asn;
+    uint32_t                timer;
+    mr_gateway_uart_stats_t uart_stats;
 } mr_uart_packet_gateway_info_t;
 
 // -------- types used for metrics collection --------

--- a/firmware/mari/packet.c
+++ b/firmware/mari/packet.c
@@ -61,14 +61,18 @@ size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, ui
     return sizeof(mr_beacon_packet_header_t);
 }
 
-size_t mr_build_uart_packet_gateway_info(uint8_t *buffer) {
+size_t mr_build_uart_packet_gateway_info(uint8_t *buffer, const mr_gateway_uart_stats_t *uart_stats) {
     mr_uart_packet_gateway_info_t gateway_info = {
+        .version     = MARI_PROTOCOL_VERSION,
         .device_id   = mr_device_id(),
         .net_id      = mr_assoc_get_network_id(),
         .schedule_id = mr_scheduler_get_active_schedule_id(),
         .asn         = mr_mac_get_asn(),
     };
     memcpy(gateway_info.sched_usage, mr_scheduler_get_schedule_usage(), sizeof(uint64_t) * MARI_STATS_SCHED_USAGE_SIZE);
+    if (uart_stats) {
+        memcpy(&gateway_info.uart_stats, uart_stats, sizeof(mr_gateway_uart_stats_t));
+    }
     memcpy(buffer, &gateway_info, sizeof(mr_uart_packet_gateway_info_t));
     return sizeof(mr_uart_packet_gateway_info_t);
 }

--- a/firmware/mari/packet.h
+++ b/firmware/mari/packet.h
@@ -42,6 +42,6 @@ size_t mr_build_packet_keepalive(uint8_t *buffer, uint64_t dst);
 
 size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, uint8_t remaining_capacity, uint8_t active_schedule_id);
 
-size_t mr_build_uart_packet_gateway_info(uint8_t *buffer);
+size_t mr_build_uart_packet_gateway_info(uint8_t *buffer, const mr_gateway_uart_stats_t *uart_stats);
 
 #endif

--- a/marilib/marilib/communication_adapter.py
+++ b/marilib/marilib/communication_adapter.py
@@ -1,6 +1,7 @@
 import base64
 import time
 from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass
 from urllib.parse import urlparse
 
 import paho.mqtt.client as mqtt
@@ -27,6 +28,25 @@ class CommunicationAdapterBase(ABC):
         """Close the interface."""
 
 
+@dataclass
+class SerialAdapterStats:
+    """Host-side counters for the UART hop, the mirror of the gateway's own.
+
+    The gateway counts what it received; these count what the host sent and
+    what came back. A discrepancy between the two sides localizes a loss to
+    the wire rather than to either endpoint.
+    """
+
+    write_calls: int = 0  # serial.write() calls, one per frame
+    write_bytes: int = 0  # HDLC-encoded bytes handed to pyserial
+    write_errors: int = 0  # writes that raised
+    rx_frames_ok: int = 0  # HDLC frames decoded from the gateway
+    rx_hdlc_err: int = 0  # frames the host decoder rejected
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
 class SerialAdapter(CommunicationAdapterBase):
     """Class used to interface with the serial port."""
 
@@ -34,6 +54,7 @@ class SerialAdapter(CommunicationAdapterBase):
         self.port = port
         self.baudrate = baudrate
         self.hdlc_handler = HDLCHandler()
+        self.stats = SerialAdapterStats()
 
     def on_byte_received(self, byte):
         self.hdlc_handler.handle_byte(byte)
@@ -45,9 +66,17 @@ class SerialAdapter(CommunicationAdapterBase):
             rx_ts_us = time.monotonic_ns() // 1000
             try:
                 payload = self.hdlc_handler.payload
-                self.on_data_received(payload, rx_ts_us)
             except HDLCDecodeException as e:
+                self.stats.rx_hdlc_err += 1
                 print(f"Error decoding payload: {e}")
+                return
+            if not payload:
+                # a short frame or a bad FCS; HDLCHandler.payload logs the
+                # reason and hands back an empty buffer
+                self.stats.rx_hdlc_err += 1
+                return
+            self.stats.rx_frames_ok += 1
+            self.on_data_received(payload, rx_ts_us)
 
     def init(self, on_data_received: callable):
         self.on_data_received = on_data_received
@@ -78,7 +107,13 @@ class SerialAdapter(CommunicationAdapterBase):
                 data[late_stamp_offset : late_stamp_offset + 8] = stamp_us.to_bytes(8, "little")
             self.serial.serial.flush()
             encoded = hdlc_encode(data)
-            self.serial.write(encoded)
+            try:
+                self.serial.write(encoded)
+            except Exception:
+                self.stats.write_errors += 1
+                raise
+            self.stats.write_calls += 1
+            self.stats.write_bytes += len(encoded)
         return stamp_us
 
 

--- a/marilib/marilib/logger.py
+++ b/marilib/marilib/logger.py
@@ -6,6 +6,30 @@ from typing import IO, List, Dict
 
 from marilib.model import MariGateway, MariNode
 
+# Counters carried in every gateway_info, named as they are in
+# mr_gateway_uart_stats_t (firmware/mari/models.h).
+GATEWAY_UART_STAT_COLUMNS = [
+    "uart_rx_bytes",
+    "uart_rx_frames_ok",
+    "uart_rx_hdlc_err",
+    "uart_rx_hw_overrun",
+    "uart_rx_hw_framing",
+    "uart_rx_hw_break",
+    "uart_rx_slot_full",
+    "uart_tx_queue_drop",
+    "ipc_u2r_lost",
+    "ipc_r2u_lost",
+]
+
+# The host's own view of the same hop, from SerialAdapterStats.
+HOST_UART_STAT_COLUMNS = [
+    "host_write_calls",
+    "host_write_bytes",
+    "host_write_errors",
+    "host_rx_frames_ok",
+    "host_rx_hdlc_err",
+]
+
 
 @dataclass
 class MetricsLogger:
@@ -101,6 +125,13 @@ class MetricsLogger:
             "latest_node_rx_count",
             "latest_gw_tx_count",
             "latest_gw_rx_count",
+            # Cumulative UART / inter-core counters, gateway side (from
+            # gateway_info) then host side (from the serial adapter). They only
+            # reset on reboot, so read them as differences between rows. Any
+            # non-zero error counter localizes a loss on the host-to-gateway
+            # hop, which nothing else in this file can see.
+            *GATEWAY_UART_STAT_COLUMNS,
+            *HOST_UART_STAT_COLUMNS,
         ]
         self._gateway_writer.writerow(gateway_header)
 
@@ -121,6 +152,12 @@ class MetricsLogger:
             "pdr_uplink",
             "radio_pdr_downlink",
             "radio_pdr_uplink",
+            # A rolling window over the last MARI_PROBE_STATS_MAX_LEN (10)
+            # probes, not a cumulative figure: the ratio is taken between the
+            # oldest and newest entries of a bounded deque. Its resolution is
+            # therefore ~1/10 per node, enough to show that several percent are
+            # being lost and never enough to certify three nines. For an exact
+            # figure over any window, pool the raw *_count columns below.
             "uart_pdr_downlink",
             "uart_pdr_uplink",
             "rssi_node_dbm",
@@ -160,10 +197,12 @@ class MetricsLogger:
         self._check_for_rotation()
         return True
 
-    def log_periodic_metrics(self, gateway: MariGateway, nodes: List[MariNode]):
+    def log_periodic_metrics(
+        self, gateway: MariGateway, nodes: List[MariNode], host_stats: Dict[str, int] | None = None
+    ):
         last_log_time = self.last_log_time.get(gateway.info.address, self.segment_start_time)
         if datetime.now() - last_log_time >= timedelta(seconds=self.log_interval_seconds):
-            self.log_gateway_metrics(gateway)
+            self.log_gateway_metrics(gateway, host_stats)
             self.log_all_nodes_metrics(nodes)
             self.last_log_time[gateway.info.address] = datetime.now()
             # Flush at the sampling rate, as log_events.csv already does. Two
@@ -174,10 +213,11 @@ class MetricsLogger:
                 if f and not f.closed:
                     f.flush()
 
-    def log_gateway_metrics(self, gateway: MariGateway):
+    def log_gateway_metrics(self, gateway: MariGateway, host_stats: Dict[str, int] | None = None):
         if not self._log_common() or self._gateway_writer is None:
             return
 
+        host_stats = host_stats or {}
         timestamp = datetime.now().isoformat()
         row = [
             timestamp,
@@ -197,6 +237,8 @@ class MetricsLogger:
             gateway.stats_latest_node_rx_count(),
             gateway.stats_latest_gw_tx_count(),
             gateway.stats_latest_gw_rx_count(),
+            *(getattr(gateway.info, name, "") for name in GATEWAY_UART_STAT_COLUMNS),
+            *(host_stats.get(name.removeprefix("host_"), "") for name in HOST_UART_STAT_COLUMNS),
         ]
         self._gateway_writer.writerow(row)
 

--- a/marilib/marilib/marilib_edge.py
+++ b/marilib/marilib/marilib_edge.py
@@ -8,6 +8,7 @@ from rich import print
 from marilib.communication_adapter import MQTTAdapter, MQTTAdapterDummy, SerialAdapter
 from marilib.mari_protocol import (
     MARI_BROADCAST_ADDRESS,
+    MARI_PROTOCOL_VERSION,
     DefaultPayload,
     DefaultPayloadType,
     Frame,
@@ -58,6 +59,11 @@ class MarilibEdge(MarilibBase):
     # generic cb_application; unmatched frames go to cb_application only.
     _proto_handlers: dict[int, Callable[[Frame], None]] = field(default_factory=dict, repr=False)
 
+    # Distinct gateway_info rejection reasons already reported. The gateway
+    # sends one gateway_info per slotframe, so an unreported mismatch would
+    # print several times a second.
+    _reported_gateway_mismatches: set[str] = field(default_factory=set, repr=False)
+
     def __post_init__(self):
         self.setup_params = {
             "main_file": self.main_file or "unknown",
@@ -77,7 +83,11 @@ class MarilibEdge(MarilibBase):
         with self.lock:
             self.gateway.update()
             if self.logger and self.logger.active:
-                self.logger.log_periodic_metrics(self.gateway, self.gateway.nodes)
+                self.logger.log_periodic_metrics(
+                    self.gateway,
+                    self.gateway.nodes,
+                    self.serial_interface.stats.as_dict(),
+                )
 
     @property
     def nodes(self) -> list[MariNode]:
@@ -261,11 +271,19 @@ class MarilibEdge(MarilibBase):
 
         if event_type == EdgeEvent.GATEWAY_INFO:
             try:
-                with self.lock:
-                    self.gateway.set_info(GatewayInfo().from_bytes(data[1:]))
-                return True, event_type, self.gateway.info
-            except (ValueError, ProtocolPayloadParserException):
+                info = GatewayInfo().from_bytes(data[1:])
+            except (ValueError, ProtocolPayloadParserException) as exc:
+                self._report_gateway_mismatch(str(exc))
                 return False, EdgeEvent.UNKNOWN, None
+            if info.version != MARI_PROTOCOL_VERSION:
+                self._report_gateway_mismatch(
+                    f"gateway speaks mari protocol v{info.version}, "
+                    f"marilib speaks v{MARI_PROTOCOL_VERSION}"
+                )
+                return False, EdgeEvent.UNKNOWN, None
+            with self.lock:
+                self.gateway.set_info(info)
+            return True, event_type, self.gateway.info
 
         elif event_type == EdgeEvent.NODE_DATA:
             try:
@@ -329,6 +347,18 @@ class MarilibEdge(MarilibBase):
         self.metrics_tester.stop()
 
     # ============================ Private methods =============================
+
+    def _report_gateway_mismatch(self, reason: str):
+        """Say once, loudly, that a gateway_info could not be used.
+
+        Reaching here means the gateway is running a firmware this marilib does
+        not understand. Nothing downstream works from that point, so the run
+        needs a matching pair reflashed rather than a silent degradation.
+        """
+        if reason in self._reported_gateway_mismatches:
+            return
+        self._reported_gateway_mismatches.add(reason)
+        print(f"[bold red]Rejecting gateway_info: {reason}[/]")
 
     def _is_test_packet(self, payload: bytes) -> bool:
         """Determines if a packet sent FROM the edge is for testing purposes."""

--- a/marilib/marilib/model.py
+++ b/marilib/marilib/model.py
@@ -6,7 +6,7 @@ from enum import IntEnum
 
 import rich
 
-from marilib.mari_protocol import Frame, MetricsProbePayload
+from marilib.mari_protocol import MARI_PROTOCOL_VERSION, Frame, MetricsProbePayload
 from marilib.probe_tracker import ProbeTracker
 from marilib.protocol import Packet, PacketFieldMetadata
 
@@ -422,22 +422,66 @@ class MariNode:
 
 @dataclass
 class GatewayInfo(Packet):
+    """Mirror of mr_uart_packet_gateway_info_t in firmware/mari/models.h.
+
+    The gateway emits one of these per slotframe. Every field after `timer` is
+    a cumulative counter that only resets when the gateway reboots, so a reader
+    takes differences between consecutive packets.
+    """
+
     metadata: list[PacketFieldMetadata] = field(
         default_factory=lambda: [
+            PacketFieldMetadata(name="version", length=1),
             PacketFieldMetadata(name="address", length=8),
             PacketFieldMetadata(name="network_id", length=2),
-            PacketFieldMetadata(name="schedule_id", length=1),
+            PacketFieldMetadata(name="schedule_id", length=2),
             PacketFieldMetadata(name="schedule_stats", length=4 * 8),  # 4 uint64_t values
             PacketFieldMetadata(name="asn", length=8),
             PacketFieldMetadata(name="timer", length=4),
+            PacketFieldMetadata(name="uart_rx_bytes", length=4),
+            PacketFieldMetadata(name="uart_rx_frames_ok", length=4),
+            PacketFieldMetadata(name="uart_rx_hdlc_err", length=4),
+            PacketFieldMetadata(name="uart_rx_hw_overrun", length=4),
+            PacketFieldMetadata(name="uart_rx_hw_framing", length=4),
+            PacketFieldMetadata(name="uart_rx_hw_break", length=4),
+            PacketFieldMetadata(name="uart_rx_slot_full", length=4),
+            PacketFieldMetadata(name="uart_tx_queue_drop", length=4),
+            PacketFieldMetadata(name="ipc_u2r_lost", length=4),
+            PacketFieldMetadata(name="ipc_r2u_lost", length=4),
         ]
     )
+    version: int = MARI_PROTOCOL_VERSION
     address: int = 0
     network_id: int = 0
     schedule_id: int = 0
     schedule_stats: bytes = b""
     asn: int = 0
     timer: int = 0
+    uart_rx_bytes: int = 0
+    uart_rx_frames_ok: int = 0
+    uart_rx_hdlc_err: int = 0
+    uart_rx_hw_overrun: int = 0
+    uart_rx_hw_framing: int = 0
+    uart_rx_hw_break: int = 0
+    uart_rx_slot_full: int = 0
+    uart_tx_queue_drop: int = 0
+    ipc_u2r_lost: int = 0
+    ipc_r2u_lost: int = 0
+
+    def from_bytes(self, bytes_):
+        """Parse a gateway_info payload, rejecting anything that is not one.
+
+        The base parser stops as soon as every field is filled, so a payload
+        built by a firmware with a different layout would be accepted with its
+        trailing bytes ignored and its fields quietly misaligned. gateway_info
+        is a fixed-size struct, so require the exact size.
+        """
+        if len(bytes_) != self.size:
+            raise ValueError(
+                f"gateway_info is {len(bytes_)} bytes, expected {self.size}: "
+                "the gateway firmware and marilib disagree on the layout"
+            )
+        return super().from_bytes(bytes_)
 
     # NOTE: maybe move to a separate class, dedicated to schedule stuff
     def repr_schedule_stats(self):
@@ -451,10 +495,9 @@ class GatewayInfo(Packet):
         all_bits.reverse()
         # print(">>>", reversed(all_bits[0].split("")))
         all_bits = [list(reversed(bits)) for bits in all_bits]
-        # now just flatten the list
+        # now just flatten the list; cell n is bit n of the little-endian
+        # sched_usage bitmap
         all_bits = [item for sublist in all_bits for item in sublist]
-        # FIXME: why do we need to skip the first byte?
-        all_bits = all_bits[8:]
         # cut it down to the number of slots
         all_bits = all_bits[: len(schedule_data["slots"])]
         return "".join(all_bits)

--- a/marilib/marilib/tui_edge.py
+++ b/marilib/marilib/tui_edge.py
@@ -293,6 +293,34 @@ class MarilibTUIEdge(MarilibTUI):
         status.append(f"TX/s: {stats.sent_count(1, include_test_packets=True)}  |  ")
         status.append(f"RX/s: {stats.received_count(1, include_test_packets=True)}")
 
+        # UART link health. The host counts what it wrote, the gateway counts
+        # what arrived, and the error counters say where anything missing went.
+        # All are cumulative since the gateway booted.
+        info = mari.gateway.info
+        host = mari.serial_interface.stats
+        errors = (
+            info.uart_rx_hdlc_err
+            + info.uart_rx_hw_overrun
+            + info.uart_rx_hw_framing
+            + info.uart_rx_hw_break
+            + info.uart_rx_slot_full
+            + info.uart_tx_queue_drop
+            + info.ipc_u2r_lost
+            + info.ipc_r2u_lost
+        )
+        status.append("\n")
+        status.append(f"UART: host TX {host.write_calls} frames / {host.write_bytes} B  |  ")
+        status.append(f"gw RX {info.uart_rx_frames_ok} frames / {info.uart_rx_bytes} B  |  ")
+        status.append("errors ")
+        status.append(f"{errors}", style="red" if errors else "green")
+        if errors:
+            status.append(
+                f" (hdlc {info.uart_rx_hdlc_err}, overrun {info.uart_rx_hw_overrun}, "
+                f"framing {info.uart_rx_hw_framing}, break {info.uart_rx_hw_break}, "
+                f"slot-full {info.uart_rx_slot_full}, txq {info.uart_tx_queue_drop}, "
+                f"ipc {info.ipc_u2r_lost}/{info.ipc_r2u_lost})"
+            )
+
         return Panel(
             status,
             title=f"[bold]MariEdge running since {mari.started_ts.strftime('%Y-%m-%d %H:%M:%S')}",

--- a/marilib/tests/test_gateway_info.py
+++ b/marilib/tests/test_gateway_info.py
@@ -1,0 +1,147 @@
+"""Tests for the gateway_info wire format.
+
+The vectors here are built the way the firmware builds the struct, from
+mr_uart_packet_gateway_info_t in firmware/mari/models.h, so a change on either
+side that is not mirrored on the other fails here rather than on the bench.
+"""
+
+import struct
+
+import pytest
+
+from marilib.mari_protocol import MARI_PROTOCOL_VERSION
+from marilib.model import GatewayInfo
+
+# struct layout, little-endian, packed:
+#   uint8_t  version
+#   uint64_t device_id
+#   uint16_t net_id
+#   uint16_t schedule_id
+#   uint64_t sched_usage[4]
+#   uint64_t asn
+#   uint32_t timer
+#   uint32_t uart_stats[10]
+GATEWAY_INFO_STRUCT = "<BQHH4QQI10I"
+GATEWAY_INFO_SIZE = 97
+
+UART_STAT_NAMES = [
+    "uart_rx_bytes",
+    "uart_rx_frames_ok",
+    "uart_rx_hdlc_err",
+    "uart_rx_hw_overrun",
+    "uart_rx_hw_framing",
+    "uart_rx_hw_break",
+    "uart_rx_slot_full",
+    "uart_tx_queue_drop",
+    "ipc_u2r_lost",
+    "ipc_r2u_lost",
+]
+
+
+def build_gateway_info(
+    version=MARI_PROTOCOL_VERSION,
+    device_id=0x1122334455667788,
+    net_id=0x0001,
+    schedule_id=1,
+    sched_usage=(0, 0, 0, 0),
+    asn=0,
+    timer=0,
+    uart_stats=(0,) * 10,
+) -> bytes:
+    """Encode a gateway_info exactly as the firmware memcpys it onto the wire."""
+    return struct.pack(
+        GATEWAY_INFO_STRUCT,
+        version,
+        device_id,
+        net_id,
+        schedule_id,
+        *sched_usage,
+        asn,
+        timer,
+        *uart_stats,
+    )
+
+
+def test_struct_layout_matches_declared_size():
+    assert struct.calcsize(GATEWAY_INFO_STRUCT) == GATEWAY_INFO_SIZE
+    assert GatewayInfo().size == GATEWAY_INFO_SIZE
+
+
+def test_roundtrip_all_fields():
+    stats = tuple(range(1, 11))
+    payload = build_gateway_info(
+        device_id=0x1122334455667788,
+        net_id=0xABCD,
+        schedule_id=3,
+        sched_usage=(0x1111111111111111, 0x2222222222222222, 0x3, 0x4),
+        asn=0xDEADBEEF,
+        timer=0x01020304,
+        uart_stats=stats,
+    )
+    info = GatewayInfo().from_bytes(payload)
+
+    assert info.version == MARI_PROTOCOL_VERSION
+    assert info.address == 0x1122334455667788
+    assert info.network_id == 0xABCD
+    assert info.schedule_id == 3
+    assert info.asn == 0xDEADBEEF
+    assert info.timer == 0x01020304
+    for name, expected in zip(UART_STAT_NAMES, stats):
+        assert getattr(info, name) == expected, name
+
+
+def test_roundtrip_sched_usage_is_read_at_the_right_offset():
+    """schedule_id is a uint16_t on the wire.
+
+    Reading it as one byte shifts sched_usage by one, which the schedule
+    rendering used to compensate for by dropping the first eight bits.
+    """
+    info = GatewayInfo().from_bytes(
+        build_gateway_info(schedule_id=1, sched_usage=(0xFF, 0, 0, 0))
+    )
+    assert info.schedule_id == 1
+    # 0x00000000000000FF as the first uint64 of a 256-bit little-endian value
+    assert info.schedule_stats == 0xFF
+
+
+def test_schedule_cell_usage_bit_n_is_cell_n():
+    """Cell n of the schedule is bit n of the sched_usage bitmap."""
+    # cells 0 and 5 in use, nothing else
+    info = GatewayInfo().from_bytes(
+        build_gateway_info(schedule_id=1, sched_usage=((1 << 0) | (1 << 5), 0, 0, 0))
+    )
+    bits = info.repr_schedule_stats()
+    assert bits[0] == "1"
+    assert bits[5] == "1"
+    assert set(bits[1:5]) == {"0"}
+    assert set(bits[6:]) == {"0"}
+
+
+def test_short_payload_is_rejected():
+    """A payload one field short must raise, not parse into garbage."""
+    payload = build_gateway_info()[:-4]
+    with pytest.raises(ValueError, match="expected 97"):
+        GatewayInfo().from_bytes(payload)
+
+
+def test_old_layout_payload_is_rejected():
+    """The pre-counter gateway_info was 56 bytes and had no version field.
+
+    Left unchecked the base parser would consume its first 56 bytes as if they
+    were the new layout and read every field from the wrong offset.
+    """
+    old_layout = struct.pack("<QHH4QQI", 0x1122334455667788, 1, 1, 0, 0, 0, 0, 0, 0)
+    assert len(old_layout) == 56
+    with pytest.raises(ValueError, match="expected 97"):
+        GatewayInfo().from_bytes(old_layout)
+
+
+def test_longer_payload_is_rejected():
+    """Extra trailing bytes mean the sender has fields we do not know about."""
+    with pytest.raises(ValueError, match="expected 97"):
+        GatewayInfo().from_bytes(build_gateway_info() + b"\x00\x00\x00\x00")
+
+
+def test_to_bytes_round_trips_through_from_bytes():
+    info = GatewayInfo().from_bytes(build_gateway_info(uart_stats=tuple(range(10, 20))))
+    assert info.to_bytes() == build_gateway_info(uart_stats=tuple(range(10, 20)))


### PR DESCRIPTION
**Superseded by #172**, which contains these two commits plus the receive-path redesign they were written to measure. Close this one and merge #172.

Kept open only so the link resolves; there is nothing here that #172 does not include.

The original intent was that this land first, so the gateway could be flashed with instrumentation and the loss attributed by cause before the code causing it was replaced. That happened during development instead: both firmwares were flashed in turn on the same bench and compared directly, which is the before/after table in #172.